### PR TITLE
refactor: remove uuid dependency and implement custom uuidv4 function

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwindcss": "^4.0.15",
-    "uuid": "^11.1.0"
+    "tailwindcss": "^4.0.15"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       tailwindcss:
         specifier: ^4.0.15
         version: 4.0.17
-      uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.21.0
@@ -2080,10 +2077,6 @@ packages:
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
-
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
 
   vite-node@3.0.8:
     resolution: {integrity: sha512-6PhR4H9VGlcwXZ+KWCdMqbtG649xCPZqfI9j2PsK1FcXgEzro5bGHcVKFCTqPLaNKZES8Evqv4LwvZARsq5qlg==}
@@ -4161,8 +4154,6 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
     optional: true
-
-  uuid@11.1.0: {}
 
   vite-node@3.0.8(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.85.1):
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef } from 'react'
-import { v4 as uuidv4 } from 'uuid'
 import { PictRunner } from './pict/pict-runner'
 import {
   HeaderArea,
@@ -11,6 +10,7 @@ import {
   ResultArea,
   FooterArea,
 } from './components'
+import { uuidv4 } from './helpers'
 import {
   PictParameter,
   PictCondition,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -17,3 +17,7 @@ export function convertConstraintWrapper(
     parameters.map((p) => p.name),
   )
 }
+
+export function uuidv4(): string {
+  return crypto.randomUUID()
+}

--- a/src/initial-parameters.ts
+++ b/src/initial-parameters.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid'
+import { uuidv4 } from './helpers'
 
 export function getInitialParameters() {
   return [


### PR DESCRIPTION
This pull request focuses on removing the `uuid` dependency and replacing its usage with a custom `uuidv4` function that utilizes the built-in `crypto.randomUUID` method. The changes span across multiple files including `package.json`, `pnpm-lock.yaml`, and various source files.

Dependency removal and replacement:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L19-R19): Removed the `uuid` dependency.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL20-L22): Removed all references to the `uuid` package. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL20-L22) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2084-L2087) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4165-L4166)

Code updates to use custom `uuidv4` function:

* [`src/App.tsx`](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L2): Replaced the import of `uuidv4` from `uuid` with the custom `uuidv4` function from `helpers`. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L2) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R13)
* [`src/helpers.ts`](diffhunk://#diff-ca5696b367d474e785317cb7a0d9853fef5729387ab8d0fab4c46268c03aae99R20-R23): Added a new `uuidv4` function that uses `crypto.randomUUID`.
* [`src/initial-parameters.ts`](diffhunk://#diff-f1a897609d3d56a6586b13fe566d9c90b1f22918c8835e2edb53cf7af08d7687L1-R1): Updated the import to use the custom `uuidv4` function.