### PR TITLE
fix: update Open Graph meta tags and bump version to 0.4.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
     <link rel="manifest" href="/site.webmanifest">
     <meta property="og:title" content="PictRider: Pairwise Testing on the Web">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://pictrider.tekeyaqa.dev">
-    <meta property="og:image" content="https://pictrider.tekeyaqa.dev/logo.png">
+    <meta property="og:url" content="https://pictrider.takeyaqa.dev">
+    <meta property="og:image" content="https://pictrider.takeyaqa.dev/logo.png">
     <link rel="stylesheet" href="/src/styles.css">
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pictrider",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This pull request includes a few minor changes to update URLs and bump the version number.

* Updated URLs in `index.html` to correct the domain name.
* Incremented the version number in `package.json` from `0.4.0` to `0.4.1`.