### PR TITLE
ci: update PNPM version to 10 in workflow configuration

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  PNPM_VERSION: 9
+  PNPM_VERSION: 10
   NODE_VERSION: 22
 
 jobs:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/check.yml` file. The change updates the `PNPM_VERSION` environment variable from version 9 to version 10.

* [`.github/workflows/check.yml`](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L8-R8): Updated `PNPM_VERSION` from 9 to 10.