### PR TITLE
chore: update version from 0.5.0-preview to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pictrider",
   "private": true,
-  "version": "0.5.0-preview",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This pull request includes a version update for the `pictrider` package.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the package version from `0.5.0-preview` to `0.5.0`.