### PR TITLE
feat: parameters and constraints limit

### DIFF
--- a/src/components/ConstraintsArea.tsx
+++ b/src/components/ConstraintsArea.tsx
@@ -85,6 +85,7 @@ function ConstraintsArea({
             type="button"
             className="w-25 cursor-pointer rounded bg-gray-500 px-3 py-2 text-white hover:bg-gray-600 disabled:cursor-not-allowed disabled:opacity-50 lg:w-50"
             onClick={onAddConstraint}
+            disabled={constraints.length >= 50}
           >
             Add Constraint
           </button>

--- a/src/components/ParametersArea.tsx
+++ b/src/components/ParametersArea.tsx
@@ -37,6 +37,7 @@ function ParametersArea({
             type="button"
             className="w-20 cursor-pointer rounded bg-gray-500 px-3 py-2 text-white hover:bg-gray-600 disabled:cursor-not-allowed disabled:opacity-50 lg:w-30"
             onClick={onAddRow}
+            disabled={parameters.length >= 50}
           >
             Add Row
           </button>

--- a/src/pages/AppMain.tsx
+++ b/src/pages/AppMain.tsx
@@ -94,6 +94,10 @@ function AppMain({ pictRunnerInjection }: AppMainProps) {
   }
 
   function addConstraint() {
+    // Limit to maximum 50 constraints
+    if (constraints.length >= 50) {
+      return
+    }
     setConstraints([...constraints, createConstraintFromParameters(parameters)])
   }
 

--- a/src/pages/AppMain.tsx
+++ b/src/pages/AppMain.tsx
@@ -163,6 +163,11 @@ function AppMain({ pictRunnerInjection }: AppMainProps) {
   }
 
   function addParameterInputRow() {
+    // Limit to maximum 50 rows
+    if (parameters.length >= 50) {
+      return
+    }
+
     const newParameter = { id: uuidv4(), name: '', values: '', isValid: true }
     setParameters([...parameters, newParameter])
     const newConstraints = constraints.map((constraint) => ({

--- a/tests/pages/AppMain.spec.tsx
+++ b/tests/pages/AppMain.spec.tsx
@@ -130,6 +130,23 @@ describe('AppMain', () => {
       expect(screen.getAllByRole('textbox')[13]).toHaveValue('')
     })
 
+    it('Should disable add row button when maximum row limit (50) is reached', async () => {
+      // Initial state - 12 textbox (6 parameter rows)
+      expect(screen.getAllByRole('textbox')).toHaveLength(12)
+
+      // Add rows until we reach the limit (50 rows)
+      // We already have 6 rows, so we need to add 44 more
+      for (let i = 0; i < 44; i++) {
+        await user.click(screen.getByRole('button', { name: 'Add Row' }))
+      }
+
+      // Verify we have 50 rows (100 textbox - 2 per row)
+      expect(screen.getAllByRole('textbox')).toHaveLength(100)
+
+      // Verify the Add Row button is disabled
+      expect(screen.getByRole('button', { name: 'Add Row' })).toBeDisabled()
+    })
+
     it('Should display error message when duplicate parameter names are found (single)', async () => {
       // act - edit parameter name to create a duplicate
       const nameInput = screen.getAllByRole('textbox')[2]

--- a/tests/pages/AppMain.spec.tsx
+++ b/tests/pages/AppMain.spec.tsx
@@ -328,6 +328,29 @@ describe('AppMain', () => {
       ).toBeDisabled()
     })
 
+    it('Should disable add constraint button when maximum constraint limit (50) is reached', async () => {
+      // arrange - enable constraints area
+      await user.click(screen.getByLabelText('Constraints'))
+
+      // Initial state - should have 1 constraint
+      expect(screen.getByText('Constraint 1')).toBeInTheDocument()
+      expect(screen.queryByText('Constraint 50')).not.toBeInTheDocument()
+
+      // Add constraints until we reach the limit (50)
+      // We already have 1 constraint, so we need to add 49 more
+      for (let i = 0; i < 49; i++) {
+        await user.click(screen.getByRole('button', { name: 'Add Constraint' }))
+      }
+
+      // Verify we have 50 constraints
+      expect(screen.getByText('Constraint 50')).toBeInTheDocument()
+
+      // Verify the Add Constraint button is disabled
+      expect(
+        screen.getByRole('button', { name: 'Add Constraint' }),
+      ).toBeDisabled()
+    })
+
     it('Should toggle condition between if and then when clicked', async () => {
       // arrange - enable constraints area
       await user.click(screen.getByLabelText('Constraints'))

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   test: {
     include: ['tests/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     environment: 'jsdom',
+    testTimeout: 10000,
   },
   define: {
     __APP_VERSION__: JSON.stringify(`v${version}`),


### PR DESCRIPTION
This pull request introduces a limit to the number of constraints and parameter rows that can be added in the application, setting the maximum to 50 for both. Additionally, it includes tests to ensure these limits are enforced correctly.

### Changes to enforce limits:

* [`src/components/ConstraintsArea.tsx`](diffhunk://#diff-3e65297137a72d7d41a879f646d471a779109c5a04dc2207598523b591e5132aR88): Disabled the "Add Constraint" button when the number of constraints reaches 50.
* [`src/components/ParametersArea.tsx`](diffhunk://#diff-727a5af1a898f43bae833c8b9c08195582d4befb1ab50832cd8a288f23bf9fccR40): Disabled the "Add Row" button when the number of parameter rows reaches 50.

### Changes to limit adding constraints and parameter rows:

* [`src/pages/AppMain.tsx`](diffhunk://#diff-493a2f3373ab82b56149cbda2b90b3db70b34b7129fb2507ed87d38a3fa85618R97-R100): Added checks in `addConstraint` and `addParameterInputRow` functions to prevent adding more than 50 constraints or parameter rows respectively. [[1]](diffhunk://#diff-493a2f3373ab82b56149cbda2b90b3db70b34b7129fb2507ed87d38a3fa85618R97-R100) [[2]](diffhunk://#diff-493a2f3373ab82b56149cbda2b90b3db70b34b7129fb2507ed87d38a3fa85618R170-R174)

### Tests to verify limits:

* [`tests/pages/AppMain.spec.tsx`](diffhunk://#diff-0a6fc60044877a7b41b50718e820dfd380fe2b188a4c2ae130f7ac1c7c65a49bR133-R149): Added tests to verify that the "Add Row" and "Add Constraint" buttons are disabled when the maximum limit of 50 is reached. [[1]](diffhunk://#diff-0a6fc60044877a7b41b50718e820dfd380fe2b188a4c2ae130f7ac1c7c65a49bR133-R149) [[2]](diffhunk://#diff-0a6fc60044877a7b41b50718e820dfd380fe2b188a4c2ae130f7ac1c7c65a49bR331-R353)