### PR TITLE
feat: csv and tsv download

### DIFF
--- a/src/components/ResultArea.tsx
+++ b/src/components/ResultArea.tsx
@@ -1,33 +1,48 @@
 import { PictOutput } from '../types'
 
+function createCsvContent(output: PictOutput) {
+  const headerRow = output.header.map((h) => `"${h.name}"`).join(',')
+  const bodyRows = output.body.map((row) =>
+    row.values.map((col) => `"${col.value}"`).join(','),
+  )
+  return [headerRow, ...bodyRows].join('\n')
+}
+
+function createTsvContent(output: PictOutput) {
+  const headerRow = output.header.map((h) => h.name).join('\t')
+  const bodyRows = output.body.map((row) =>
+    row.values.map((col) => col.value).join('\t'),
+  )
+  return [headerRow, ...bodyRows].join('\n')
+}
+
 interface ResultAreaProps {
   output: PictOutput | null
 }
 
 function ResultArea({ output }: ResultAreaProps) {
-  function handleDownloadCSV() {
+  function handleDownload(type: 'csv' | 'tsv') {
     if (!output) {
       return
     }
 
-    // Create CSV content
-    const headerRow = output.header.map((h) => `"${h.name}"`).join(',')
-    const bodyRows = output.body.map((row) =>
-      row.values.map((col) => `"${col.value}"`).join(','),
-    )
-    const csvContent = [headerRow, ...bodyRows].join('\n')
+    const content =
+      type === 'csv' ? createCsvContent(output) : createTsvContent(output)
+    const mimeType = type === 'csv' ? 'text/csv' : 'text/tab-separated-values'
+    const fileName = type === 'csv' ? 'result.csv' : 'result.tsv'
 
     // Create a blob and download link
-    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
+    const blob = new Blob([content], { type: `${mimeType};charset=utf-8;` })
     const url = URL.createObjectURL(blob)
     const link = document.createElement('a')
     link.setAttribute('href', url)
-    link.setAttribute('download', 'result.csv')
+    link.setAttribute('download', fileName)
     link.style.visibility = 'hidden'
     document.body.appendChild(link)
     link.click()
     document.body.removeChild(link)
   }
+
   if (!output) {
     return null
   }
@@ -38,13 +53,26 @@ function ResultArea({ output }: ResultAreaProps) {
         <h2 className="text-xl font-bold" id="result_heading">
           Result
         </h2>
-        <button
-          type="button"
-          className="cursor-pointer rounded bg-green-600 px-3 py-2 text-white hover:bg-green-700"
-          onClick={handleDownloadCSV}
-        >
-          CSV
-        </button>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            className="cursor-pointer rounded bg-green-600 px-3 py-2 text-white hover:bg-green-700"
+            onClick={() => {
+              handleDownload('csv')
+            }}
+          >
+            CSV
+          </button>
+          <button
+            type="button"
+            className="cursor-pointer rounded bg-green-600 px-3 py-2 text-white hover:bg-green-700"
+            onClick={() => {
+              handleDownload('tsv')
+            }}
+          >
+            TSV
+          </button>
+        </div>
       </div>
       <div className="overflow-x-auto">
         <table

--- a/src/components/ResultArea.tsx
+++ b/src/components/ResultArea.tsx
@@ -5,15 +5,52 @@ interface ResultAreaProps {
 }
 
 function ResultArea({ output }: ResultAreaProps) {
+  function handleDownloadCSV() {
+    if (!output) {
+      return
+    }
+
+    // Create CSV content
+    const headerRow = output.header.map((h) => `"${h.name}"`).join(',')
+    const bodyRows = output.body.map((row) =>
+      row.values.map((col) => `"${col.value}"`).join(','),
+    )
+    const csvContent = [headerRow, ...bodyRows].join('\n')
+
+    // Create a blob and download link
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.setAttribute('href', url)
+    link.setAttribute('download', 'result.csv')
+    link.style.visibility = 'hidden'
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+  }
   if (!output) {
     return null
   }
 
   return (
     <section className="mx-2 mb-10 rounded-md border-2 bg-gray-50 p-7 shadow-md md:mx-10">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-xl font-bold" id="result_heading">
+          Result
+        </h2>
+        <button
+          type="button"
+          className="cursor-pointer rounded bg-green-600 px-3 py-2 text-white hover:bg-green-700"
+          onClick={handleDownloadCSV}
+        >
+          CSV
+        </button>
+      </div>
       <div className="overflow-x-auto">
-        <table className="w-full table-fixed border-collapse">
-          <caption className="mb-3 text-left text-xl font-bold">Result</caption>
+        <table
+          className="w-full table-fixed border-collapse"
+          aria-labelledby="result_heading"
+        >
           <thead>
             <tr className="bg-gray-100">
               <th className="border border-black px-4 py-2 text-left font-bold">

--- a/tests/pages/AppMain.spec.tsx
+++ b/tests/pages/AppMain.spec.tsx
@@ -493,12 +493,26 @@ describe('AppMain', () => {
 
       // assert - check result table
       expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-      expect(screen.getByRole('caption')).toHaveTextContent('Result')
-      expect(screen.getByRole('table')).toBeInTheDocument()
+      expect(screen.getByRole('table', { name: 'Result' })).toBeInTheDocument()
       expect(
         screen.getByRole('columnheader', { name: 'Type' }),
       ).toBeInTheDocument()
       expect(screen.getByRole('cell', { name: '100' })).toBeInTheDocument()
+
+      // Check that the Download CSV button is present
+      expect(screen.getByRole('button', { name: 'CSV' })).toBeInTheDocument()
+    })
+
+    it('Should have a Download CSV button that is enabled after running PICT', async () => {
+      // Run PICT to get results
+      await user.click(screen.getByText('Run'))
+
+      // Get the Download CSV button and verify it exists and is enabled
+      const downloadButton = screen.getByRole('button', {
+        name: 'CSV',
+      })
+      expect(downloadButton).toBeInTheDocument()
+      expect(downloadButton).not.toBeDisabled()
     })
 
     it('Should call with parameters when input default value', async () => {

--- a/tests/pages/AppMain.spec.tsx
+++ b/tests/pages/AppMain.spec.tsx
@@ -499,20 +499,24 @@ describe('AppMain', () => {
       ).toBeInTheDocument()
       expect(screen.getByRole('cell', { name: '100' })).toBeInTheDocument()
 
-      // Check that the Download CSV button is present
+      // Check that the CSV and TSV buttons are present
       expect(screen.getByRole('button', { name: 'CSV' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'TSV' })).toBeInTheDocument()
     })
 
-    it('Should have a Download CSV button that is enabled after running PICT', async () => {
+    it('Should have CSV and TSV buttons that are enabled after running PICT', async () => {
       // Run PICT to get results
       await user.click(screen.getByText('Run'))
 
-      // Get the Download CSV button and verify it exists and is enabled
-      const downloadButton = screen.getByRole('button', {
-        name: 'CSV',
-      })
-      expect(downloadButton).toBeInTheDocument()
-      expect(downloadButton).not.toBeDisabled()
+      // Get the CSV button and verify it exists and is enabled
+      const csvButton = screen.getByRole('button', { name: 'CSV' })
+      expect(csvButton).toBeInTheDocument()
+      expect(csvButton).not.toBeDisabled()
+
+      // Get the TSV button and verify it exists and is enabled
+      const tsvButton = screen.getByRole('button', { name: 'TSV' })
+      expect(tsvButton).toBeInTheDocument()
+      expect(tsvButton).not.toBeDisabled()
     })
 
     it('Should call with parameters when input default value', async () => {


### PR DESCRIPTION
This pull request introduces a feature to download results as CSV or TSV files and updates the relevant tests to ensure this new functionality works correctly. The most important changes include adding functions to create CSV and TSV content, implementing a download handler, and updating the UI and tests.

### New download functionality:

* [`src/components/ResultArea.tsx`](diffhunk://#diff-100e194570a2831533c2bbe8617264a645d5038388ec015b9871c444be93f3f0R3-R81): Added `createCsvContent` and `createTsvContent` functions to generate CSV and TSV content from the output, respectively. Implemented `handleDownload` function to handle file download logic and added buttons to the UI for downloading results as CSV or TSV.

### Test updates:

* [`tests/pages/AppMain.spec.tsx`](diffhunk://#diff-0a6fc60044877a7b41b50718e820dfd380fe2b188a4c2ae130f7ac1c7c65a49bL496-R519): Updated tests to check for the presence of CSV and TSV buttons and added a new test to ensure these buttons are enabled after running PICT.