### PR TITLE
feat: add model file display option and update related components

### DIFF
--- a/e2e/all.spec.ts
+++ b/e2e/all.spec.ts
@@ -172,3 +172,18 @@ test('should display result after clicking Run (combination 3)', async ({
   await expect(lastDataRow.getByRole('cell').nth(3)).toHaveText('Slow')
   await expect(lastDataRow.getByRole('cell').nth(4)).toHaveText('FAT32')
 })
+
+test('should display result after clicking Run (with display model file)', async ({
+  page,
+}) => {
+  // arrange
+  await page.goto('/')
+
+  // act
+  await page.getByRole('checkbox', { name: 'Show model file' }).click()
+  await page.getByRole('button', { name: 'Run' }).click()
+
+  // assert
+  await expect(page.getByRole('heading', { name: 'Model File' })).toBeVisible()
+  await expect(page.getByRole('table', { name: 'Result' })).toBeVisible()
+})

--- a/src/components/OptionsArea.tsx
+++ b/src/components/OptionsArea.tsx
@@ -3,7 +3,7 @@ import { PictConfig } from '../types'
 interface OptionsAreaProps {
   config: PictConfig
   handleChangeConfig: (
-    type: 'enableConstraints' | 'orderOfCombinations',
+    type: 'enableConstraints' | 'showModelFile' | 'orderOfCombinations',
     e?: React.ChangeEvent<HTMLInputElement>,
   ) => void
 }
@@ -26,6 +26,21 @@ function OptionsArea({ config, handleChangeConfig }: OptionsAreaProps) {
               }}
             />
             Constraints
+          </label>
+        </div>
+        <div>
+          <label className="cursor-pointer" htmlFor="show-model-file-button">
+            <input
+              type="checkbox"
+              className="mr-1 cursor-pointer rounded"
+              id="show-model-file-button"
+              autoComplete="off"
+              checked={config.showModelFile}
+              onChange={() => {
+                handleChangeConfig('showModelFile')
+              }}
+            />
+            Show model file
           </label>
         </div>
         <div>

--- a/src/components/ResultArea.tsx
+++ b/src/components/ResultArea.tsx
@@ -1,4 +1,4 @@
-import { PictOutput } from '../types'
+import { PictConfig, PictOutput } from '../types'
 
 function createCsvContent(output: PictOutput) {
   const headerRow = output.header.map((h) => `"${h.name}"`).join(',')
@@ -17,10 +17,11 @@ function createTsvContent(output: PictOutput) {
 }
 
 interface ResultAreaProps {
+  config: PictConfig
   output: PictOutput | null
 }
 
-function ResultArea({ output }: ResultAreaProps) {
+function ResultArea({ config, output }: ResultAreaProps) {
   function handleDownload(type: 'csv' | 'tsv') {
     if (!output) {
       return
@@ -47,8 +48,25 @@ function ResultArea({ output }: ResultAreaProps) {
     return null
   }
 
+  let modelFile = <></>
+  if (config.showModelFile) {
+    modelFile = (
+      <div>
+        <h2 className="text-xl font-bold" id="model_label">
+          Model File
+        </h2>
+        <div>
+          <pre className="my-3 rounded-md border-2 bg-white p-4 font-mono">
+            {output.modelFile}
+          </pre>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <section className="mx-2 mb-10 rounded-md border-2 bg-gray-50 p-7 shadow-md md:mx-10">
+      {modelFile}
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-xl font-bold" id="result_heading">
           Result

--- a/src/pages/AppMain.tsx
+++ b/src/pages/AppMain.tsx
@@ -89,6 +89,7 @@ function AppMain({ pictRunnerInjection }: AppMainProps) {
   const [constraintsError, setConstraintsError] = useState<string[]>([])
   const [config, setConfig] = useState<PictConfig>({
     enableConstraints: false,
+    showModelFile: false,
     orderOfCombinations: 2,
   })
   const [output, setOutput] = useState<PictOutput | null>(null)
@@ -185,13 +186,17 @@ function AppMain({ pictRunnerInjection }: AppMainProps) {
   }
 
   function handleChangeConfig(
-    type: 'enableConstraints' | 'orderOfCombinations',
+    type: 'enableConstraints' | 'showModelFile' | 'orderOfCombinations',
     e?: React.ChangeEvent<HTMLInputElement>,
   ) {
     const newConfig = { ...config }
     switch (type) {
       case 'enableConstraints': {
         newConfig.enableConstraints = !config.enableConstraints
+        break
+      }
+      case 'showModelFile': {
+        newConfig.showModelFile = !config.showModelFile
         break
       }
       case 'orderOfCombinations': {
@@ -404,7 +409,7 @@ function AppMain({ pictRunnerInjection }: AppMainProps) {
           }),
         }
       })
-      setOutput({ header, body })
+      setOutput({ header, body, modelFile: output.modelFile })
       setErrorMessage('')
     } catch (e) {
       if (e instanceof Error) {
@@ -442,7 +447,7 @@ function AppMain({ pictRunnerInjection }: AppMainProps) {
         onClickRun={runPict}
       />
       <ErrorMessageArea message={errorMessage} />
-      <ResultArea output={output} />
+      <ResultArea config={config} output={output} />
     </main>
   )
 }

--- a/src/pict/pict-runner.ts
+++ b/src/pict/pict-runner.ts
@@ -65,7 +65,7 @@ export class PictRunner {
       .split('\n')
       .map((m) => m.split('\t'))
     this.stdoutCapture.clear()
-    return { header: out[0], body: out.slice(1) }
+    return { header: out[0], body: out.slice(1), modelFile: model }
   }
 }
 

--- a/src/pict/pict-types.ts
+++ b/src/pict/pict-types.ts
@@ -16,6 +16,7 @@ export interface Constraint {
 export interface Output {
   header: string[]
   body: string[][]
+  modelFile: string
 }
 
 export interface Options {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,9 +21,11 @@ export interface PictConstraint {
 export interface PictOutput {
   header: { id: number; name: string }[]
   body: { id: number; values: { id: number; value: string }[] }[]
+  modelFile: string
 }
 
 export interface PictConfig {
   enableConstraints: boolean
+  showModelFile: boolean
   orderOfCombinations: number
 }


### PR DESCRIPTION
This pull request introduces a new feature to display the model file in the results and includes several changes across multiple files to support this functionality. The most important changes include modifications to the configuration handling, updates to the result display, and adjustments to the test cases.

### Configuration Handling:
* [`src/components/OptionsArea.tsx`](diffhunk://#diff-13cddce7b8c680bc03b2d02f21eb79af4c24fe7bff332503b25f0ae125644782L6-R6): Added a new checkbox for 'Show model file' in the options area and updated the `handleChangeConfig` function to handle this new option. [[1]](diffhunk://#diff-13cddce7b8c680bc03b2d02f21eb79af4c24fe7bff332503b25f0ae125644782L6-R6) [[2]](diffhunk://#diff-13cddce7b8c680bc03b2d02f21eb79af4c24fe7bff332503b25f0ae125644782R31-R45)
* [`src/pages/AppMain.tsx`](diffhunk://#diff-493a2f3373ab82b56149cbda2b90b3db70b34b7129fb2507ed87d38a3fa85618R92): Updated the `PictConfig` state to include `showModelFile`, and modified the `handleChangeConfig` function to toggle this option. [[1]](diffhunk://#diff-493a2f3373ab82b56149cbda2b90b3db70b34b7129fb2507ed87d38a3fa85618R92) [[2]](diffhunk://#diff-493a2f3373ab82b56149cbda2b90b3db70b34b7129fb2507ed87d38a3fa85618L188-R189) [[3]](diffhunk://#diff-493a2f3373ab82b56149cbda2b90b3db70b34b7129fb2507ed87d38a3fa85618R198-R201)

### Result Display:
* [`src/components/ResultArea.tsx`](diffhunk://#diff-100e194570a2831533c2bbe8617264a645d5038388ec015b9871c444be93f3f0L1-R1): Added logic to conditionally display the model file in the results area if the `showModelFile` option is enabled. [[1]](diffhunk://#diff-100e194570a2831533c2bbe8617264a645d5038388ec015b9871c444be93f3f0L1-R1) [[2]](diffhunk://#diff-100e194570a2831533c2bbe8617264a645d5038388ec015b9871c444be93f3f0R20-R24) [[3]](diffhunk://#diff-100e194570a2831533c2bbe8617264a645d5038388ec015b9871c444be93f3f0R51-R69)
* [`src/pages/AppMain.tsx`](diffhunk://#diff-493a2f3373ab82b56149cbda2b90b3db70b34b7129fb2507ed87d38a3fa85618L445-R450): Passed the `config` prop to the `ResultArea` component to control the display of the model file.

### Data Handling:
* [`src/pict/pict-runner.ts`](diffhunk://#diff-0e84d255a6005b23ca0e0d9bfac03f25522e25fb6efc5299e025d71631c46cf8L68-R68): Modified the `PictRunner` class to include the model file in the output.
* [`src/pict/pict-types.ts`](diffhunk://#diff-2cb3d980a143fbf15cbf8537658185d464b6b971ce405903f0d711ad04ccd997R19): Updated the `Output` interface to include the `modelFile` property.
* [`src/types.ts`](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR24-R29): Updated the `PictOutput` interface to include the `modelFile` property.

### Testing:
* [`e2e/all.spec.ts`](diffhunk://#diff-cd860249ab2e74853ba9cffa0e3f1771f2fbd062ca8382a90d0032c3dcd8483fR175-R189): Added a new test case to verify that the model file is displayed when the 'Show model file' checkbox is checked and the 'Run' button is clicked.