### PR TITLE
chore: update version from 0.6.0-preview to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pictrider",
   "private": true,
-  "version": "0.6.0-preview",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This pull request includes a version update for the `pictrider` project in the `package.json` file. The version has been changed from `0.6.0-preview` to `0.6.0`, indicating the transition from a preview release to a stable release.