### PR TITLE
chore: update version from 0.6.0 to 0.7.0-preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pictrider",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0-preview",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This pull request updates the version of the `pictrider` package to reflect a new preview release.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Changed the version from `0.6.0` to `0.7.0-preview` to indicate a preview release.