### PR TITLE
feat: add VITE_APP_VERSION environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
+VITE_APP_VERSION=development
 VITE_BASE_DOMAIN=pictrider.example.com
 VITE_NOTIFICATION_MESSAGE=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,7 @@
 name: deploy
 on:
-  push:
-    branches: [main]
   release:
-    types: [released]
-  workflow_dispatch:
+    types: [published]
 
 env:
   PNPM_VERSION: 10
@@ -27,18 +24,14 @@ jobs:
           cache: pnpm
       - run: pnpm install
       - run: pnpm run build
-      - name: Set branch name
-        id: set_branch_name
-        run: |
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            echo "BRANCH_NAME=main" >> "$GITHUB_OUTPUT"
-          else
-            echo "BRANCH_NAME=edge" >> "$GITHUB_OUTPUT"
-          fi
+        env:
+          VITE_APP_VERSION: ${{ github.event.release.tag_name }}
+          VITE_BASE_DOMAIN: ${{ vars.BASE_DOMAIN }}
+          VITE_NOTIFICATION_MESSAGE: ${{ vars.NOTIFICATION_MESSAGE }}
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          command: pages deploy dist --project-name=pictrider --branch=${{ steps.set_branch_name.outputs.BRANCH_NAME }}
+          command: pages deploy dist --project-name=pictrider --branch=main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,7 @@ Available environment variables:
 
 | Variable         | Description | Default               |
 | ---------------- | ----------- | --------------------- |
+| VITE_APP_VERSION | App version | development           |
 | VITE_BASE_DOMAIN | Base domain | pictrider.example.com |
 
 ## Build and Test Commands

--- a/src/components/HeaderArea.tsx
+++ b/src/components/HeaderArea.tsx
@@ -47,7 +47,7 @@ function HeaderArea() {
               <img src="/github-mark.svg" alt="GitHub" width="25" height="25" />
             </a>
           </li>
-          <li>{__APP_VERSION__}</li>
+          <li>{import.meta.env.VITE_APP_VERSION}</li>
         </ul>
       </nav>
     </header>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,13 +1,11 @@
 /// <reference types="vite/client" />
 
-declare const __APP_VERSION__: string
-declare const __NOTIFICATION_MESSAGE__: string
-
 interface ViteTypeOptions {
   strictImportMetaEnv: unknown
 }
 
 interface ImportMetaEnv {
+  readonly VITE_APP_VERSION: string
   readonly VITE_BASE_DOMAIN: string
   readonly VITE_NOTIFICATION_MESSAGE: string
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,6 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import license from 'rollup-plugin-license'
 import path from 'path'
-import { version } from './package.json'
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -24,8 +23,5 @@ export default defineConfig({
   },
   optimizeDeps: {
     exclude: ['@takeyaqa/pict-browser'],
-  },
-  define: {
-    __APP_VERSION__: JSON.stringify(`v${version}`),
   },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
-import { version } from './package.json'
 
 export default defineConfig({
   plugins: [react()],
@@ -8,8 +7,5 @@ export default defineConfig({
     include: ['tests/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     environment: 'jsdom',
     testTimeout: 10000,
-  },
-  define: {
-    __APP_VERSION__: JSON.stringify(`v${version}`),
   },
 })


### PR DESCRIPTION
This pull request introduces changes to improve version management, streamline deployment workflows, and simplify the configuration files. The most important changes include replacing the hardcoded `__APP_VERSION__` with the `VITE_APP_VERSION` environment variable, updating the deployment workflow to use release tags, and cleaning up unused configurations in the Vite and Vitest configuration files.

### Version Management Improvements:
* Introduced a new `VITE_APP_VERSION` environment variable in `.env.example` to manage the app version dynamically.
* Updated `HeaderArea.tsx` to use `import.meta.env.VITE_APP_VERSION` instead of the hardcoded `__APP_VERSION__`.
* Documented the `VITE_APP_VERSION` variable in `CONTRIBUTING.md`.

### Deployment Workflow Enhancements:
* Modified `.github/workflows/deploy.yml` to use the release tag (`github.event.release.tag_name`) for `VITE_APP_VERSION` and removed logic for determining the branch name. The deployment now always targets the `main` branch. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L3-R4) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L30-R37)

### Configuration Simplification:
* Removed the `__APP_VERSION__` definition from `vite.config.ts` and `vitest.config.ts`, as it is now replaced by the `VITE_APP_VERSION` environment variable. [[1]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL6) [[2]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL28-L30) [[3]](diffhunk://#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92L3) [[4]](diffhunk://#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92L12-L14)