### PR TITLE
refactor: rename Pict types to remove prefix and update related components

### DIFF
--- a/src/components/ConstraintsArea.tsx
+++ b/src/components/ConstraintsArea.tsx
@@ -1,4 +1,4 @@
-import { PictParameter, PictConstraint, PictConfig } from '../types'
+import { Parameter, Constraint, Config } from '../types'
 import { printConstraints } from '../pict/pict-helper'
 
 interface ConstraintTableCell {
@@ -20,8 +20,8 @@ interface ConstraintTableRow {
  * to avoid repetitive lookups in the JSX
  */
 function buildConstraintTable(
-  parameters: PictParameter[],
-  constraints: PictConstraint[],
+  parameters: Parameter[],
+  constraints: Constraint[],
 ): ConstraintTableRow[] {
   return parameters.map((parameter) => {
     const cells = constraints.map((constraint) => {
@@ -52,8 +52,8 @@ function buildConstraintTable(
 }
 
 function convertConstraintWrapper(
-  constraints: PictConstraint[],
-  parameters: PictParameter[],
+  constraints: Constraint[],
+  parameters: Parameter[],
 ): string {
   return printConstraints(
     constraints.map((c) => ({
@@ -76,9 +76,9 @@ function convertConstraintWrapper(
 }
 
 interface ConstraintsAreaProps {
-  config: PictConfig
-  parameters: PictParameter[]
-  constraints: PictConstraint[]
+  config: Config
+  parameters: Parameter[]
+  constraints: Constraint[]
   messages: string[]
   handleToggleCondition: (constraintId: string, parameterId: string) => void
   handleChangeCondition: (

--- a/src/components/OptionsArea.tsx
+++ b/src/components/OptionsArea.tsx
@@ -1,7 +1,7 @@
-import { PictConfig } from '../types'
+import { Config } from '../types'
 
 interface OptionsAreaProps {
-  config: PictConfig
+  config: Config
   handleChangeConfig: (
     type:
       | 'enableSubModels'

--- a/src/components/ParametersArea.tsx
+++ b/src/components/ParametersArea.tsx
@@ -1,7 +1,7 @@
-import { PictParameter } from '../types'
+import { Parameter } from '../types'
 
 interface ParametersAreaProps {
-  parameters: PictParameter[]
+  parameters: Parameter[]
   messages: string[]
   handleChangeParameter: (
     id: string,

--- a/src/components/ResultArea.tsx
+++ b/src/components/ResultArea.tsx
@@ -1,6 +1,6 @@
-import { PictConfig, PictOutput } from '../types'
+import { Config, Output } from '../types'
 
-function createCsvContent(output: PictOutput) {
+function createCsvContent(output: Output) {
   const headerRow = output.header.map((h) => `"${h.name}"`).join(',')
   const bodyRows = output.body.map((row) =>
     row.values.map((col) => `"${col.value}"`).join(','),
@@ -8,7 +8,7 @@ function createCsvContent(output: PictOutput) {
   return [headerRow, ...bodyRows].join('\n')
 }
 
-function createTsvContent(output: PictOutput) {
+function createTsvContent(output: Output) {
   const headerRow = output.header.map((h) => h.name).join('\t')
   const bodyRows = output.body.map((row) =>
     row.values.map((col) => col.value).join('\t'),
@@ -17,8 +17,8 @@ function createTsvContent(output: PictOutput) {
 }
 
 interface ResultAreaProps {
-  config: PictConfig
-  output: PictOutput | null
+  config: Config
+  output: Output | null
 }
 
 function ResultArea({ config, output }: ResultAreaProps) {

--- a/src/components/RunButtonArea.tsx
+++ b/src/components/RunButtonArea.tsx
@@ -1,8 +1,8 @@
-import { PictConstraint, PictParameter } from '../types'
+import { Constraint, Parameter } from '../types'
 
 interface RunButtonAreaProps {
-  parameters: PictParameter[]
-  constraints: PictConstraint[]
+  parameters: Parameter[]
+  constraints: Constraint[]
   pictRunnerLoaded: boolean
   onClickRun: () => void
 }

--- a/src/components/SubModelsArea.tsx
+++ b/src/components/SubModelsArea.tsx
@@ -1,8 +1,8 @@
-import { PictConfig, PictParameter, SubModel } from '../types'
+import { Config, Parameter, SubModel } from '../types'
 
 interface SubModelsAreaProps {
-  config: PictConfig
-  parameters: PictParameter[]
+  config: Config
+  parameters: Parameter[]
   subModels: SubModel[]
   handleChangeSubModelParameters: (
     id: string,

--- a/src/pages/AppMain.tsx
+++ b/src/pages/AppMain.tsx
@@ -8,15 +8,9 @@ import {
   ResultArea,
   SubModelsArea,
 } from '../components'
-import { PictOutput } from '../types'
+import { Result } from '../types'
 import { getInitialModel, modelReducer } from '../reducers/model-reducer'
 import { configReducer, getInitialConfig } from '../reducers/config-reducer'
-
-// Interface for the combined output and error state
-interface PictResult {
-  output: PictOutput | null
-  errorMessage: string
-}
 
 interface AppMainProps {
   pictRunnerInjection?: PictRunner // use for testing
@@ -25,7 +19,7 @@ interface AppMainProps {
 function AppMain({ pictRunnerInjection }: AppMainProps) {
   const [model, dispatchModel] = useReducer(modelReducer, getInitialModel())
   const [config, dispatchConfig] = useReducer(configReducer, getInitialConfig())
-  const [result, setResult] = useState<PictResult>({
+  const [result, setResult] = useState<Result>({
     output: null,
     errorMessage: '',
   })

--- a/src/pict/pict-helper.ts
+++ b/src/pict/pict-helper.ts
@@ -1,4 +1,4 @@
-import { Condition, Constraint } from './pict-types'
+import { PictCondition, PictConstraint } from './pict-types'
 import {
   Constraints as ConstraintsAst,
   Predicate,
@@ -32,14 +32,14 @@ interface UnfixedRelationTerm {
 }
 
 export function printConstraints(
-  constraint: Constraint[],
+  constraint: PictConstraint[],
   parameters: string[],
 ): string {
   return printCodeFromAST(convertTableToConstraints(constraint, parameters))
 }
 
 function convertTableToConstraints(
-  constraints: Constraint[],
+  constraints: PictConstraint[],
   parameters: string[],
 ): ConstraintsAst {
   const constraintsAst: ConstraintsAst = []
@@ -118,7 +118,7 @@ function convertIfOrThenConstraint(predicates: Predicate[]): Predicate {
 }
 
 function convertPredicate(
-  condition: Condition,
+  condition: PictCondition,
   parameters: Set<string>,
 ): Predicate {
   const tokens = condition.predicate.split(',').map((token) => token.trim())
@@ -217,7 +217,7 @@ function fixRestTerm(
   ]
 }
 
-function isError(conditions: Condition[]): boolean {
+function isError(conditions: PictCondition[]): boolean {
   for (const cond of conditions) {
     // '#' is only allowed at the beginning of the predicate
     if (cond.predicate.includes('#') && !cond.predicate.startsWith('#')) {

--- a/src/pict/pict-runner.ts
+++ b/src/pict/pict-runner.ts
@@ -1,8 +1,8 @@
 import {
-  Parameter,
-  Constraint,
-  Output,
-  Options,
+  PictParameter,
+  PictConstraint,
+  PictOutput,
+  PictOptions,
   PictSubModel,
 } from './pict-types'
 import { printConstraints } from './pict-helper'
@@ -26,17 +26,17 @@ export class PictRunner {
   }
 
   public run(
-    parameters: Parameter[],
+    parameters: PictParameter[],
     {
       subModels,
       constraints,
       options,
     }: {
       subModels?: PictSubModel[]
-      constraints?: Constraint[]
-      options?: Options
+      constraints?: PictConstraint[]
+      options?: PictOptions
     },
-  ): Output {
+  ): PictOutput {
     if (!this.pict) {
       throw new Error('PictRunner not initialized')
     }

--- a/src/pict/pict-types.ts
+++ b/src/pict/pict-types.ts
@@ -1,4 +1,4 @@
-export interface Parameter {
+export interface PictParameter {
   name: string
   values: string
 }
@@ -8,24 +8,24 @@ export interface PictSubModel {
   order: number
 }
 
-export interface Condition {
+export interface PictCondition {
   ifOrThen: 'if' | 'then'
   parameter: string
   predicate: string
 }
 
-export interface Constraint {
-  conditions: Condition[]
+export interface PictConstraint {
+  conditions: PictCondition[]
 }
 
-export interface Output {
+export interface PictOutput {
   header: string[]
   body: string[][]
   modelFile: string
   message?: string
 }
 
-export interface Options {
+export interface PictOptions {
   orderOfCombinations: number
   randomizeGeneration: boolean
   randomizeSeed?: number

--- a/src/reducers/config-reducer.ts
+++ b/src/reducers/config-reducer.ts
@@ -1,4 +1,4 @@
-import { PictConfig } from '../types'
+import { Config } from '../types'
 
 interface ConfigAction {
   type:
@@ -11,10 +11,7 @@ interface ConfigAction {
   payload: { e: React.ChangeEvent<HTMLInputElement> }
 }
 
-export function configReducer(
-  state: PictConfig,
-  action: ConfigAction,
-): PictConfig {
+export function configReducer(state: Config, action: ConfigAction): Config {
   const newConfig = { ...state }
   switch (action.type) {
     case 'enableSubModels': {
@@ -56,7 +53,7 @@ export function configReducer(
   }
 }
 
-export function getInitialConfig(): PictConfig {
+export function getInitialConfig(): Config {
   return {
     enableSubModels: false,
     enableConstraints: false,

--- a/src/reducers/model-reducer.ts
+++ b/src/reducers/model-reducer.ts
@@ -1,9 +1,4 @@
-import {
-  PictConstraint,
-  PictParameter,
-  PictCondition,
-  SubModel,
-} from '../types'
+import { Constraint, Parameter, Condition, Model } from '../types'
 import { uuidv4 } from '../helpers'
 
 const invalidParameterNameCharacters = [
@@ -62,14 +57,6 @@ const invalidConstraintCharacters = [
   ';', // constraints terminator
 ]
 
-interface PictModel {
-  parameters: PictParameter[]
-  constraints: PictConstraint[]
-  subModels: SubModel[]
-  parameterErrors: string[]
-  constraintErrors: string[]
-}
-
 type ModelAction =
   | {
       type: 'changeParameter'
@@ -117,7 +104,7 @@ type ModelAction =
         | 'clickRemoveConstraint'
     }
 
-export function modelReducer(state: PictModel, action: ModelAction): PictModel {
+export function modelReducer(state: Model, action: ModelAction): Model {
   // Copy the state to avoid mutating it directly
   const newParameters = state.parameters.map((parameter) => ({
     ...parameter,
@@ -463,7 +450,7 @@ export function modelReducer(state: PictModel, action: ModelAction): PictModel {
   }
 }
 
-export function getInitialModel(): PictModel {
+export function getInitialModel(): Model {
   const initialParameters = [
     {
       id: uuidv4(),
@@ -523,10 +510,8 @@ export function getInitialModel(): PictModel {
   }
 }
 
-function createConstraintFromParameters(
-  parameters: PictParameter[],
-): PictConstraint {
-  const conditions: PictCondition[] = parameters.map((p) => {
+function createConstraintFromParameters(parameters: Parameter[]): Constraint {
+  const conditions: Condition[] = parameters.map((p) => {
     return {
       ifOrThen: 'if',
       predicate: '',
@@ -538,10 +523,10 @@ function createConstraintFromParameters(
 }
 
 function searchCondition(
-  constraints: PictConstraint[],
+  constraints: Constraint[],
   constraintId: string,
   parameterId: string,
-): PictCondition {
+): Condition {
   const constraint = constraints.find((c) => c.id === constraintId)
   if (!constraint) {
     throw new Error('Constraint not found')

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export interface PictParameter {
+export interface Parameter {
   id: string
   name: string
   values: string
@@ -12,26 +12,39 @@ export interface SubModel {
   order: number
 }
 
-export interface PictCondition {
+export interface Condition {
   ifOrThen: 'if' | 'then'
   predicate: string
   parameterId: string
   isValid: boolean
 }
 
-export interface PictConstraint {
+export interface Constraint {
   id: string
-  conditions: PictCondition[]
+  conditions: Condition[]
 }
 
-export interface PictOutput {
+export interface Model {
+  parameters: Parameter[]
+  constraints: Constraint[]
+  subModels: SubModel[]
+  parameterErrors: string[]
+  constraintErrors: string[]
+}
+
+export interface Output {
   header: { id: number; name: string }[]
   body: { id: number; values: { id: number; value: string }[] }[]
   modelFile: string
   message?: string
 }
 
-export interface PictConfig {
+export interface Result {
+  output: Output | null
+  errorMessage: string
+}
+
+export interface Config {
   enableSubModels: boolean
   enableConstraints: boolean
   showModelFile: boolean

--- a/tests/pict/pict-helper.spec.ts
+++ b/tests/pict/pict-helper.spec.ts
@@ -1,10 +1,10 @@
 import { it, describe, expect } from 'vitest'
 import { printConstraints } from '../../src/pict/pict-helper'
-import { Constraint } from '../../src/pict/pict-types'
+import { PictConstraint } from '../../src/pict/pict-types'
 
 describe('convertConstraints', () => {
   it('should convert basic constraint (1)', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -26,7 +26,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert basic constraint (2)', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -48,7 +48,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert basic constraint (3)', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -70,7 +70,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert basic constraint (4)', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -92,7 +92,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert basic constraint (5)', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -121,7 +121,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert basic constraint (6)', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -150,7 +150,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert basic constraint (7)', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -172,7 +172,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert basic constraint (8)', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -201,7 +201,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert basic constraint (9)', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -230,7 +230,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert basic constraint (10)', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -259,7 +259,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert basic constraint (11)', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -288,7 +288,7 @@ describe('convertConstraints', () => {
   })
 
   it('should not convert error constraint', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -310,7 +310,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert parameter and parameter constraint (1)', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -332,7 +332,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert parameter and parameter constraint (2)', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -354,7 +354,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert parameter and parameter constraint (3)', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -376,7 +376,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert parameter and parameter constraint (4)', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -398,7 +398,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert condition less constraint 1', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -425,7 +425,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert condition less constraint 2', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -449,7 +449,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert wildcard constraint', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -471,7 +471,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert a simple constraint with one if and one then condition', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -493,7 +493,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert a constraint with double if conditions', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -526,7 +526,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert a constraint with triple if conditions', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -565,7 +565,7 @@ describe('convertConstraints', () => {
   })
 
   it('should convert a constraint with multiple then conditions', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -598,7 +598,7 @@ describe('convertConstraints', () => {
   })
 
   it('should ignore conditions with empty predicates', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -635,7 +635,7 @@ describe('convertConstraints', () => {
   })
 
   it('should return an empty string when no valid conditions exist', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -657,7 +657,7 @@ describe('convertConstraints', () => {
   })
 
   it('should return an empty string with only if conditions', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {
@@ -680,7 +680,7 @@ describe('convertConstraints', () => {
   })
 
   it('should handle a constraint with only then conditions', () => {
-    const constraints: Constraint[] = [
+    const constraints: PictConstraint[] = [
       {
         conditions: [
           {


### PR DESCRIPTION
This pull request refactors the naming conventions of several types across the codebase to improve clarity and consistency. Specifically, it removes the `Pict` prefix from types used in the application while retaining it for types specific to the `pict` library. The changes span multiple files, including components, reducers, and tests, and ensure that the updated type names are used consistently throughout the project.

### Type Renaming and Consolidation:
* Removed the `Pict` prefix from generic types like `PictParameter`, `PictConstraint`, and `PictConfig` and renamed them to `Parameter`, `Constraint`, and `Config` respectively in `src/types.ts` and all related files. (`[[1]](diffhunk://#diff-3e65297137a72d7d41a879f646d471a779109c5a04dc2207598523b591e5132aL1-R1)`, `[[2]](diffhunk://#diff-2cb3d980a143fbf15cbf8537658185d464b6b971ce405903f0d711ad04ccd997L1-R1)`, `[[3]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL1-R1)R1`)
* Retained the `Pict` prefix for `pict`-specific types such as `PictCondition`, `PictConstraint`, and `PictOutput` in `src/pict/pict-types.ts` and updated their usage in relevant files. (`[[1]](diffhunk://#diff-36e7f6e2be373f9a92099da90607807439e8997e66d83d6fc336322d52d1c592L1-R1)`, `[[2]](diffhunk://#diff-0e84d255a6005b23ca0e0d9bfac03f25522e25fb6efc5299e025d71631c46cf8L2-R5)`)

### Updates to Components:
* Updated type imports and props in all components (e.g., `ConstraintsArea.tsx`, `OptionsArea.tsx`, `ParametersArea.tsx`) to use the renamed types (`Parameter`, `Constraint`, `Config`, etc.). (`[[1]](diffhunk://#diff-3e65297137a72d7d41a879f646d471a779109c5a04dc2207598523b591e5132aL1-R1)`, `[[2]](diffhunk://#diff-13cddce7b8c680bc03b2d02f21eb79af4c24fe7bff332503b25f0ae125644782L1-R4)`, `[[3]](diffhunk://#diff-727a5af1a898f43bae833c8b9c08195582d4befb1ab50832cd8a288f23bf9fccL1-R4)`, `[[4]](diffhunk://#diff-100e194570a2831533c2bbe8617264a645d5038388ec015b9871c444be93f3f0L1-R11)`, `[[5]](diffhunk://#diff-0472d38d2818546ac0210c8bae683e5683d89b1d7ed262405c0c9d196acaf4b1L1-R5)`, `[[6]](diffhunk://#diff-81e118c9695343b6c7c7267b7ed7411052b0f04ca77dceb47d3a9edfa1f8ad98L1-R5)`)

### Reducers and State Management:
* Refactored the `modelReducer` and `configReducer` functions to use the updated type names (`Model`, `Config`, etc.) and adjusted the initial state functions accordingly. (`[[1]](diffhunk://#diff-0410c19a51ab4ea97d85ee0fa9bdc632561b900dc8d047bbc4e073f40bd6b704L1-R1)`, `[[2]](diffhunk://#diff-d7af39cc88e6deb0158068e02c1baca15c4a0ed76f04af3e55c5b27c50875e1cL1-R1)`)
* Updated the state type for `result` in `AppMain.tsx` to use the renamed `Result` interface. (`[src/pages/AppMain.tsxL11-R22](diffhunk://#diff-493a2f3373ab82b56149cbda2b90b3db70b34b7129fb2507ed87d38a3fa85618L11-R22)`)

### Test Adjustments:
* Updated tests in `pict-helper.spec.ts` to use the `PictConstraint` type instead of the generic `Constraint` type, ensuring alignment with the `pict` library's domain-specific naming. (`[[1]](diffhunk://#diff-2d93ff47cb80b7388e787bab223691117f11d4691bccb596100c6d28589726acL3-R7)`, `[[2]](diffhunk://#diff-2d93ff47cb80b7388e787bab223691117f11d4691bccb596100c6d28589726acL29-R29)`)

### `pict` Library Specific Changes:
* Ensured that `pict-helper.ts` and `pict-runner.ts` continue to use `Pict`-prefixed types for clarity in distinguishing `pict`-specific logic. (`[[1]](diffhunk://#diff-36e7f6e2be373f9a92099da90607807439e8997e66d83d6fc336322d52d1c592L1-R1)`, `[[2]](diffhunk://#diff-0e84d255a6005b23ca0e0d9bfac03f25522e25fb6efc5299e025d71631c46cf8L2-R5)`)