### PR TITLE
fix: enhance randomization tests to validate seed usage and handle zero seed case

### DIFF
--- a/e2e/all.spec.ts
+++ b/e2e/all.spec.ts
@@ -196,9 +196,23 @@ test('should display result after clicking Run (with randomize generation)', asy
 
   // act
   await page.getByRole('checkbox', { name: 'Randomize generation' }).click()
-  await page.getByRole('spinbutton', { name: 'Seed' }).fill('1234')
   await page.getByRole('button', { name: 'Run' }).click()
 
   // assert
-  await expect(page.getByRole('alert')).toContainText('Used seed: 1234')
+  await expect(page.getByRole('alert')).toContainText(/Used seed: [0-9]+/)
+})
+
+test('should display result after clicking Run (with randomize generation and define seed)', async ({
+  page,
+}) => {
+  // arrange
+  await page.goto('/')
+
+  // act
+  await page.getByRole('checkbox', { name: 'Randomize generation' }).click()
+  await page.getByRole('spinbutton', { name: 'Seed' }).fill('0')
+  await page.getByRole('button', { name: 'Run' }).click()
+
+  // assert
+  await expect(page.getByRole('alert')).toContainText('Used seed: 0')
 })

--- a/src/pict/pict-runner.ts
+++ b/src/pict/pict-runner.ts
@@ -60,7 +60,7 @@ export class PictRunner {
         switches.push(`/o:${options.orderOfCombinations.toString()}`)
       }
       if (options.randomizeGeneration) {
-        if (options.randomizeSeed) {
+        if (options.randomizeSeed === 0 || options.randomizeSeed) {
           switches.push(`/r:${options.randomizeSeed.toString()}`)
         } else {
           switches.push('/r')


### PR DESCRIPTION
This pull request introduces updates to the random seed handling logic and its corresponding test cases. The changes ensure better flexibility and accuracy when specifying or randomizing seeds in the application.

### Updates to random seed handling:

* [`src/pict/pict-runner.ts`](diffhunk://#diff-0e84d255a6005b23ca0e0d9bfac03f25522e25fb6efc5299e025d71631c46cf8L63-R63): Modified the condition for `options.randomizeSeed` to explicitly allow a seed value of `0`, ensuring it is treated as a valid input. This change improves the handling of edge cases where `0` was previously ignored.

### Updates to test cases:

* [`e2e/all.spec.ts`](diffhunk://#diff-cd860249ab2e74853ba9cffa0e3f1771f2fbd062ca8382a90d0032c3dcd8483fL199-R217): Updated the test for random seed generation to validate against any numeric seed using a regular expression. Added a new test case to verify behavior when explicitly defining a seed value of `0`. These changes enhance test coverage for the random seed functionality.