### PR TITLE
fix: replace NotLikeTerm with NotClause and update related logic

### DIFF
--- a/src/pict-constraints-parser/printer.ts
+++ b/src/pict-constraints-parser/printer.ts
@@ -46,8 +46,6 @@ function printTerm(term: Term): string {
     }
     case 'LikeTerm':
       return `[${term.parameter}] LIKE "${term.patternString}"`
-    case 'NotLikeTerm':
-      return `[${term.parameter}] NOT LIKE "${term.patternString}"`
     case 'InTerm':
       return `[${term.parameter}] IN { ${generateValueSet(term.values)} }`
     default:

--- a/src/pict-constraints-parser/types.ts
+++ b/src/pict-constraints-parser/types.ts
@@ -39,7 +39,7 @@ export interface NotClause {
 }
 
 // Term
-export type Term = RelationTerm | LikeTerm | NotLikeTerm | InTerm
+export type Term = RelationTerm | LikeTerm | InTerm
 
 export interface RelationTerm {
   type: 'RelationTerm'
@@ -50,12 +50,6 @@ export interface RelationTerm {
 
 export interface LikeTerm {
   type: 'LikeTerm'
-  parameter: string
-  patternString: string
-}
-
-export interface NotLikeTerm {
-  type: 'NotLikeTerm'
   parameter: string
   patternString: string
 }

--- a/tests/helpers.spec.ts
+++ b/tests/helpers.spec.ts
@@ -467,7 +467,7 @@ describe('convertConstraints', () => {
     ]
 
     const result = printConstraints(constraints, ['A', 'B', 'C'])
-    expect(result).toBe('IF [B] LIKE "*B*" THEN [C] NOT LIKE "C??";')
+    expect(result).toBe('IF [B] LIKE "*B*" THEN NOT [C] LIKE "C??";')
   })
 
   it('should convert a simple constraint with one if and one then condition', () => {

--- a/tests/pict-constraints-parser/printer.spec.ts
+++ b/tests/pict-constraints-parser/printer.spec.ts
@@ -101,14 +101,17 @@ describe('printCodeFromAST', () => {
       const constraint: PredicateConstraint = {
         type: 'PredicateConstraint',
         predicate: {
-          type: 'NotLikeTerm',
-          parameter: 'Parameter1',
-          patternString: 'pattern*',
+          type: 'NotClause',
+          predicate: {
+            type: 'LikeTerm',
+            parameter: 'Parameter1',
+            patternString: 'pattern*',
+          },
         },
       }
 
       const result = printCodeFromAST([constraint])
-      expect(result).toBe('[Parameter1] NOT LIKE "pattern*";')
+      expect(result).toBe('NOT [Parameter1] LIKE "pattern*";')
     })
 
     it('should print an IN term', () => {


### PR DESCRIPTION
This pull request refactors the handling of negated "LIKE" terms in the constraint-conversion logic by replacing the `NotLikeTerm` type with a more generalized `NotClause` type. The changes ensure a more consistent and extensible representation of negated clauses throughout the codebase. The updates span type definitions, logic for term conversion, and related test cases.

### Refactoring of Negated "LIKE" Terms:

* Replaced `NotLikeTerm` with `NotClause` in type definitions (`src/pict-constraints-parser/types.ts`) and updated the `Term` type to reflect this change. [[1]](diffhunk://#diff-65ee45e0b2464d99ea337b79d32297dc1fc594d7371a25b36e9352e7887fa926L42-R42) [[2]](diffhunk://#diff-65ee45e0b2464d99ea337b79d32297dc1fc594d7371a25b36e9352e7887fa926L57-L62)
* Updated the `convertTerm` function to create a `NotClause` instead of a `NotLikeTerm` for "NOT LIKE" relations and included the nested `LikeTerm` predicate.

### Updates to Constraint Conversion Logic:

* Modified the `UnfixedTerm` type in `src/constraint-converter.ts` to replace `NotLikeTerm` with `NotClause`.
* Updated the `convertPredicate` and `fixFirstTerm` functions to handle `Clause` instead of `Term` for negated terms. [[1]](diffhunk://#diff-f6cddf20900f7f8ff3dc9264dbac8761121bf486362f6f5940e9b3cae0064ca4L126-R126) [[2]](diffhunk://#diff-f6cddf20900f7f8ff3dc9264dbac8761121bf486362f6f5940e9b3cae0064ca4L142-R142) [[3]](diffhunk://#diff-f6cddf20900f7f8ff3dc9264dbac8761121bf486362f6f5940e9b3cae0064ca4L162-R162)

### Updates to Printing Logic:

* Removed the handling of `NotLikeTerm` in the `printTerm` function and adjusted the output format for `NotClause` to reflect the new structure.

### Test Case Updates:

* Updated test cases in `tests/helpers.spec.ts` and `tests/pict-constraints-parser/printer.spec.ts` to validate the new `NotClause` structure and its output format. [[1]](diffhunk://#diff-0c140153bb2ad1109475fbdf63e0dc3531834346bc06be28a67c5b8ded633bc1L470-R470) [[2]](diffhunk://#diff-747d55bea83251baf32f10a2094b568707404c2bc88b016782ec290e994235feL104-R114)