### PR TITLE
fix: remove comma from invalid constraint characters and update message

### DIFF
--- a/src/reducers/model-reducer.ts
+++ b/src/reducers/model-reducer.ts
@@ -47,7 +47,6 @@ const invalidConstraintCharacters = [
   '(', // values weight identifier
   ')', // values weight identifier
   '|', // values alias identifier
-  ',', // values separator
   '~', // values negation identifier
   '{', // sub-models identifier
   '}', // sub-models identifier

--- a/tests/pages/AppMain.spec.tsx
+++ b/tests/pages/AppMain.spec.tsx
@@ -578,7 +578,7 @@ describe('AppMain', () => {
 
       await user.type(inputs[0], '@')
       expect(screen.getByRole('alert')).toHaveTextContent(
-        'Constraints cannot contain special characters: ":", "(", ")", "|", ",", "~", "{", "}", "@", "[", "]", ";',
+        'Constraints cannot contain special characters: ":", "(", ")", "|", "~", "{", "}", "@", "[", "]", ";',
       )
       expect(screen.getByRole('button', { name: 'Run' })).toBeDisabled()
 


### PR DESCRIPTION
This pull request includes two changes related to the handling of constraint characters in the application. The most important updates involve removing the comma (`,`) as a restricted character and updating corresponding test cases to reflect this change.

### Updates to constraint character handling:
* [`src/reducers/model-reducer.ts`](diffhunk://#diff-0410c19a51ab4ea97d85ee0fa9bdc632561b900dc8d047bbc4e073f40bd6b704L50): Removed the comma (`,`) from the `invalidConstraintCharacters` array, indicating it is no longer considered a restricted character.

### Updates to test cases:
* [`tests/pages/AppMain.spec.tsx`](diffhunk://#diff-0a6fc60044877a7b41b50718e820dfd380fe2b188a4c2ae130f7ac1c7c65a49bL581-R581): Updated the error message in the test for invalid constraint characters to exclude the comma (`,`) from the list of special characters.