### PR TITLE
chore: update version from 0.8.0 to 0.9.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pictrider",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This pull request updates the version of the `pictrider` project in the `package.json` file.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Incremented the project version from `0.8.0` to `0.9.0`.