### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pictrider",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This pull request updates the version number in the `package.json` file to reflect a new release.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the `version` field from `0.10.0` to `0.11.0` to indicate a new version of the project.