### PR TITLE
feat: Add Clear Result button functionality in ResultSection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -264,7 +264,13 @@ function App({ pictRunnerInjection }: AppProps) {
           pictRunnerLoaded={pictRunnerLoaded}
           onClickRun={runPict}
         />
-        <ResultSection config={config} result={result} />
+        <ResultSection
+          config={config}
+          result={result}
+          handleClearResult={() => {
+            setResult(null)
+          }}
+        />
       </main>
       <FooterSection />
       <Analytics />

--- a/src/sections/ResultSection.tsx
+++ b/src/sections/ResultSection.tsx
@@ -20,9 +20,14 @@ function createTsvContent(result: Result) {
 interface ResultSectionProps {
   config: Config
   result: Result | null
+  handleClearResult: () => void
 }
 
-function ResultSection({ config, result }: ResultSectionProps) {
+function ResultSection({
+  config,
+  result,
+  handleClearResult,
+}: ResultSectionProps) {
   function handleDownload(type: 'csv' | 'tsv') {
     if (!result) {
       return
@@ -73,6 +78,12 @@ function ResultSection({ config, result }: ResultSectionProps) {
           Result
         </h2>
         <div className="flex gap-2">
+          <Button
+            type="warning"
+            label="Clear Result"
+            size="sm"
+            onClick={handleClearResult}
+          />
           <Button
             type="success"
             label="CSV"

--- a/tests/App.spec.tsx
+++ b/tests/App.spec.tsx
@@ -739,6 +739,22 @@ describe('App', () => {
       expect(tsvButton).not.toBeDisabled()
     })
 
+    it('Should clear results when clicking the Clear Result button', async () => {
+      // Run PICT to get results
+      await user.click(screen.getByRole('button', { name: 'Run' }))
+
+      // Verify result table is displayed
+      expect(screen.getByRole('table', { name: 'Result' })).toBeInTheDocument()
+
+      // Click the Clear Result button
+      await user.click(screen.getByRole('button', { name: 'Clear Result' }))
+
+      // Verify result table is no longer displayed
+      expect(
+        screen.queryByRole('table', { name: 'Result' }),
+      ).not.toBeInTheDocument()
+    })
+
     it('Should call with parameters when input default value', async () => {
       // act - click the run button
       await user.click(screen.getByRole('button', { name: 'Run' }))


### PR DESCRIPTION
This pull request introduces a new feature to clear the results in the application, along with its corresponding UI updates and tests. The most important changes involve adding a "Clear Result" button, updating the `ResultSection` component to handle this functionality, and writing a test to ensure the feature works as expected.

### Feature Addition: Clear Results Functionality

* **UI Update in `App.tsx`:** The `ResultSection` component now includes a `handleClearResult` prop, which clears the results by setting them to `null`. This enables the "Clear Result" functionality.

* **Enhancements in `ResultSection.tsx`:**
  - The `ResultSection` component was updated to accept a `handleClearResult` prop, which is invoked when the "Clear Result" button is clicked.
  - Added a "Clear Result" button to the UI, styled as a small warning button, and wired it to the `handleClearResult` function.

### Testing

* **Test Case in `App.spec.tsx`:** A new test was added to verify that clicking the "Clear Result" button removes the result table from the UI. This ensures the feature behaves as expected.