### PR TITLE
fix: Enhance convertTerm to validate parameter names with operators

### DIFF
--- a/src/constraint-converter.ts
+++ b/src/constraint-converter.ts
@@ -229,7 +229,7 @@ function convertTerm(
     if (isPatternString(predicate)) {
       isParameterName = false
       break
-    } else if (predicate.includes(parameter)) {
+    } else if (predicate.includes(parameter) && /^[=!&].+$/.test(predicate)) {
       isParameterName = true
       break
     }

--- a/src/constraint-converter.ts
+++ b/src/constraint-converter.ts
@@ -225,11 +225,11 @@ function convertTerm(
   parameters: Set<string>,
 ): UnfixedTerm {
   let isParameterName = false
-  for (const parameter of parameters) {
+  for (const p of parameters) {
     if (isPatternString(predicate)) {
       isParameterName = false
       break
-    } else if (predicate.includes(parameter) && /^[=!&].+$/.test(predicate)) {
+    } else if (predicate.includes(p) && /^[=!&].+$/.test(predicate)) {
       isParameterName = true
       break
     }

--- a/tests/helpers.spec.ts
+++ b/tests/helpers.spec.ts
@@ -309,6 +309,28 @@ describe('convertConstraints', () => {
     expect(result).toBeUndefined()
   })
 
+  it('should not convert parameter name without operator', () => {
+    const constraints: FixedConstraint[] = [
+      {
+        conditions: [
+          {
+            ifOrThen: 'if',
+            parameterName: 'A',
+            predicate: 'B',
+          },
+          {
+            ifOrThen: 'then',
+            parameterName: 'C',
+            predicate: '100',
+          },
+        ],
+      },
+    ]
+
+    const result = printConstraints(constraints, ['A', 'B', 'C', 'D'])[0]
+    expect(result).toBe('IF [A] = "B" THEN [C] = 100;')
+  })
+
   it('should convert parameter and parameter constraint (1)', () => {
     const constraints: FixedConstraint[] = [
       {


### PR DESCRIPTION
This pull request introduces a bug fix to the `convertTerm` function and adds a corresponding test case to verify the behavior. The changes ensure that parameter names are only recognized when the predicate includes an operator.

### Bug fix in `convertTerm` function:

* Updated the condition in `src/constraint-converter.ts` to ensure that a predicate must include an operator (e.g., `=`, `!`, `&`) to be treated as a parameter name. This prevents incorrect identification of parameter names when no operator is present.

### Test case addition:

* Added a new test in `tests/helpers.spec.ts` to validate that a parameter name is not converted if the predicate lacks an operator. This ensures the correctness of the updated logic in `convertTerm`.