### PR TITLE
docs: Remove logo image from README and about page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # PictRider
 
-<img src="public/logo.svg" alt="PictRider Logo" width="640">
-
 ## Pairwise Testing on the Web
 
 PictRider is a modern and user-friendly combinatorial testing tool that allows you to easily generate test cases using pairwise testing techniques directly on the web. It requires no installation and runs entirely in the browser, enabling QA engineers and software developers to quickly and efficiently design effective test cases.
@@ -30,7 +28,7 @@ Pairwise testing is especially effective when:
 
 PictRider is an open-source project. The source code is available on GitHub:
 
-<https://github.com/takeyaqa/PictRider>
+[https://github.com/takeyaqa/PictRider](https://github.com/takeyaqa/PictRider)
 
 Contributions, bug reports, and feature requests are welcome!
 

--- a/about.html
+++ b/about.html
@@ -30,10 +30,6 @@
         <h2 class="mb-6 text-2xl font-bold">About PictRider</h2>
 
         <p class="mb-4">
-          <img src="/logo.svg" alt="PictRider Logo" width="640" />
-        </p>
-
-        <p class="mb-4">
           <strong class="text-xl font-bold">
             Pairwise Testing on the Web
           </strong>


### PR DESCRIPTION
This pull request includes minor updates to the `README.md` and `about.html` files to improve formatting and remove redundant elements.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-L4): Removed the logo image at the top of the file and updated the GitHub link to use Markdown link syntax for better readability. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-L4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R31)

### HTML adjustments:

* [`about.html`](diffhunk://#diff-2212b84a2a6ffe239872c76d266680d86f2438391034b2eb19604f17104f6968L32-L35): Removed the logo image from the "About PictRider" section to streamline the page layout.