### PR TITLE
chore: update version to 0.12.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pictrider",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This pull request includes a version bump for the `pictrider` project in the `package.json` file. The version has been updated from `0.11.0` to `0.12.0` to reflect the latest changes.