### PR TITLE
feat: Multiple Sub-models

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -174,17 +174,19 @@ function App({ pictRunnerInjection }: AppProps) {
       .filter((p) => p.name !== '' && p.values !== '')
       .map((p) => ({ name: p.name, values: p.values }))
     const fixedSubModels = config.enableSubModels
-      ? model.subModels.map((s) => ({
-          parameterNames: s.parameterIds.map((id) => {
-            const parameter = model.parameters.find((p) => p.id === id)
-            if (!parameter) {
-              throw new Error(`Parameter not found: ${id}`)
-            }
-            return parameter.name
-          }),
-          order: s.order,
-        }))
-      : undefined
+      ? model.subModels
+          .filter((sm) => sm.parameterIds.length > 0)
+          .map((s) => ({
+            parameterNames: s.parameterIds.map((id) => {
+              const parameter = model.parameters.find((p) => p.id === id)
+              if (!parameter) {
+                throw new Error(`Parameter not found: ${id}`)
+              }
+              return parameter.name
+            }),
+            order: s.order,
+          }))
+      : []
     const pictOptions = {
       orderOfCombinations:
         config.orderOfCombinations !== '' ? config.orderOfCombinations : 2,

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -12,7 +12,7 @@ function Checkbox({ label, checked, onChange }: CheckboxProps) {
     <Field className="flex items-center">
       <HeadlessUiCheckbox
         checked={checked}
-        className="group mr-1 flex size-5 rounded bg-white ring-1 ring-gray-400 data-checked:bg-blue-500"
+        className="group mr-1 flex size-5 cursor-pointer rounded bg-white ring-1 ring-gray-400 data-checked:bg-blue-500"
         onChange={onChange}
       >
         <CheckIcon className="hidden fill-white group-data-checked:inline" />

--- a/src/reducers/model-reducer.ts
+++ b/src/reducers/model-reducer.ts
@@ -609,6 +609,11 @@ export function getInitialModel(): Model {
         parameterIds: [],
         order: 2,
       },
+      {
+        id: uuidv4(),
+        parameterIds: [],
+        order: 2,
+      },
     ],
     constraints: [createConstraintFromParameters(initialParameters)],
     constraintTexts: [],

--- a/src/sections/SubModelsSection.tsx
+++ b/src/sections/SubModelsSection.tsx
@@ -42,45 +42,51 @@ function SubModelsSection({
           />
         </div>
       </div>
-      {config.enableSubModels &&
-        subModels.map((subModel) => (
-          <div className="mb-5 grid grid-cols-12 gap-5" key={subModel.id}>
-            <div className="col-span-3">
-              <div className="flex flex-col">
-                <h3 className="mb-2">Parameters</h3>
-                {parameters.map((parameter) => (
-                  <div
-                    key={`${subModel.id}-${parameter.id}`}
-                    className="mb-1 items-center"
-                  >
-                    <Checkbox
-                      label={parameter.name}
-                      checked={subModel.parameterIds.includes(parameter.id)}
-                      onChange={(checked) => {
-                        handleClickSubModelParameters(
-                          subModel.id,
-                          parameter.id,
-                          checked,
-                        )
-                      }}
-                    />
-                  </div>
-                ))}
+      <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-2">
+        {config.enableSubModels &&
+          subModels.map((subModel, i) => (
+            <div
+              key={subModel.id}
+              className="mb-5 grid grid-cols-2 place-items-center gap-5"
+            >
+              <div>
+                <h3 className="text-base font-bold">Sub Model {i + 1}</h3>
+                <div>
+                  <h4 className="mb-2">Parameters</h4>
+                  {parameters.map((parameter) => (
+                    <div
+                      key={`${subModel.id}-${parameter.id}`}
+                      className="mb-1 items-center"
+                    >
+                      <Checkbox
+                        label={parameter.name}
+                        checked={subModel.parameterIds.includes(parameter.id)}
+                        onChange={(checked) => {
+                          handleClickSubModelParameters(
+                            subModel.id,
+                            parameter.id,
+                            checked,
+                          )
+                        }}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <NumberInput
+                  label="Order"
+                  value={subModel.order}
+                  min={2}
+                  max={parameters.length}
+                  onChange={(e) => {
+                    handleChangeSubModelOrder(subModel.id, e)
+                  }}
+                />
               </div>
             </div>
-            <div className="col-span-2">
-              <NumberInput
-                label="Order"
-                value={subModel.order}
-                min={2}
-                max={parameters.length}
-                onChange={(e) => {
-                  handleChangeSubModelOrder(subModel.id, e)
-                }}
-              />
-            </div>
-          </div>
-        ))}
+          ))}
+      </div>
     </Section>
   )
 }

--- a/src/sections/SubModelsSection.tsx
+++ b/src/sections/SubModelsSection.tsx
@@ -50,7 +50,7 @@ function SubModelsSection({
               className="mb-5 grid grid-cols-2 place-items-center gap-5"
             >
               <div>
-                <h3 className="text-base font-bold">Sub Model {i + 1}</h3>
+                <h3 className="text-base font-bold">Sub-Model {i + 1}</h3>
                 <div>
                   <h4 className="mb-2">Parameters</h4>
                   {parameters.map((parameter) => (

--- a/src/sections/SubModelsSection.tsx
+++ b/src/sections/SubModelsSection.tsx
@@ -50,9 +50,8 @@ function SubModelsSection({
               className="mb-5 grid grid-cols-2 place-items-center gap-5"
             >
               <div>
-                <h3 className="text-base font-bold">Sub-Model {i + 1}</h3>
+                <h3 className="mb-1 text-base font-bold">Sub-Model {i + 1}</h3>
                 <div>
-                  <h4 className="mb-2">Parameters</h4>
                   {parameters.map((parameter) => (
                     <div
                       key={`${subModel.id}-${parameter.id}`}

--- a/tests/App.spec.tsx
+++ b/tests/App.spec.tsx
@@ -446,8 +446,11 @@ describe('App', () => {
         screen.queryByRole('heading', { level: 2, name: 'Sub-Models' }),
       ).toBeInTheDocument()
       expect(
-        screen.queryAllByRole('heading', { level: 4, name: 'Parameters' }),
-      ).toHaveLength(2)
+        screen.queryByRole('heading', { level: 3, name: 'Sub-Model 1' }),
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole('heading', { level: 3, name: 'Sub-Model 2' }),
+      ).toBeInTheDocument()
       expect(
         screen.queryAllByRole('spinbutton', { name: 'Order' }),
       ).toHaveLength(2)

--- a/tests/App.spec.tsx
+++ b/tests/App.spec.tsx
@@ -446,11 +446,11 @@ describe('App', () => {
         screen.queryByRole('heading', { level: 2, name: 'Sub-Models' }),
       ).toBeInTheDocument()
       expect(
-        screen.queryByRole('heading', { level: 3, name: 'Parameters' }),
-      ).toBeInTheDocument()
+        screen.queryAllByRole('heading', { level: 4, name: 'Parameters' }),
+      ).toHaveLength(2)
       expect(
-        screen.queryByRole('spinbutton', { name: 'Order' }),
-      ).toBeInTheDocument()
+        screen.queryAllByRole('spinbutton', { name: 'Order' }),
+      ).toHaveLength(2)
     })
 
     it('Should change sub-model name when parameter name is changed', async () => {
@@ -468,8 +468,8 @@ describe('App', () => {
 
       // assert - the sub-model name should be updated
       expect(
-        screen.queryByRole('checkbox', { name: 'TypeTypeType' }),
-      ).toBeInTheDocument()
+        screen.queryAllByRole('checkbox', { name: 'TypeTypeType' }),
+      ).toHaveLength(2)
     })
   })
 
@@ -1087,11 +1087,16 @@ describe('App', () => {
       await user.click(
         screen.getByRole('switch', { name: 'Enable Sub-Models' }),
       )
-      await user.click(screen.getByRole('checkbox', { name: 'Type' }))
-      await user.click(screen.getByRole('checkbox', { name: 'Size' }))
-      await user.click(screen.getByRole('checkbox', { name: 'Format method' }))
-      await user.clear(screen.getByRole('spinbutton', { name: 'Order' }))
-      await user.type(screen.getByRole('spinbutton', { name: 'Order' }), '3')
+      await user.click(screen.getAllByRole('checkbox', { name: 'Type' })[0])
+      await user.click(screen.getAllByRole('checkbox', { name: 'Size' })[0])
+      await user.click(
+        screen.getAllByRole('checkbox', { name: 'Format method' })[0],
+      )
+      await user.clear(screen.getAllByRole('spinbutton', { name: 'Order' })[0])
+      await user.type(
+        screen.getAllByRole('spinbutton', { name: 'Order' })[0],
+        '3',
+      )
 
       // act - click the run button
       await user.click(screen.getByRole('button', { name: 'Run' }))
@@ -1138,12 +1143,17 @@ describe('App', () => {
       await user.click(
         screen.getByRole('switch', { name: 'Enable Sub-Models' }),
       )
-      await user.click(screen.getByRole('checkbox', { name: 'Type' }))
-      await user.click(screen.getByRole('checkbox', { name: 'Size' }))
-      await user.click(screen.getByRole('checkbox', { name: 'Format method' }))
+      await user.click(screen.getAllByRole('checkbox', { name: 'Type' })[0])
+      await user.click(screen.getAllByRole('checkbox', { name: 'Size' })[0])
+      await user.click(
+        screen.getAllByRole('checkbox', { name: 'Format method' })[0],
+      )
 
-      await user.clear(screen.getByRole('spinbutton', { name: 'Order' }))
-      await user.type(screen.getByRole('spinbutton', { name: 'Order' }), '3')
+      await user.clear(screen.getAllByRole('spinbutton', { name: 'Order' })[0])
+      await user.type(
+        screen.getAllByRole('spinbutton', { name: 'Order' })[0],
+        '3',
+      )
 
       // act - click the run button
       await user.click(
@@ -1229,7 +1239,7 @@ describe('App', () => {
         ],
         {
           constraintsText: 'IF [Type] = "RAID-5" THEN [Size] > 1000;',
-          subModels: undefined,
+          subModels: [],
           options: expect.anything(),
         },
       )


### PR DESCRIPTION
This pull request introduces several updates to enhance the handling of sub-models, improve UI interactions, and update the associated tests to reflect these changes. The most significant changes include filtering sub-models with no parameters, updating UI layouts and styles for sub-models, and refining test cases to align with the new behavior.

### Enhancements to sub-model handling:
* Updated the logic in `src/App.tsx` to filter out sub-models with no parameters and ensure an empty array is returned when sub-models are disabled instead of `undefined`. This improves robustness and consistency in sub-model handling. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L177-R179) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L187-R189)
* Added a default sub-model to the initial model state in `src/reducers/model-reducer.ts` to ensure sub-models are pre-configured with default values.

### UI improvements for sub-models:
* Modified the layout in `src/sections/SubModelsSection.tsx` to display sub-models in a more structured grid format and updated the sub-model headings to include sequential numbering (e.g., "Sub-Model 1"). [[1]](diffhunk://#diff-e17aeaba3aa0e5624bdc5627f6730c1725828a2522979a53e502b61cd2073e93R45-R54) [[2]](diffhunk://#diff-e17aeaba3aa0e5624bdc5627f6730c1725828a2522979a53e502b61cd2073e93L71-R75) [[3]](diffhunk://#diff-e17aeaba3aa0e5624bdc5627f6730c1725828a2522979a53e502b61cd2073e93R88)
* Added a `cursor-pointer` style to the checkbox component in `src/components/Checkbox.tsx` to improve usability.

### Test updates:
* Updated test cases in `tests/App.spec.tsx` to validate the new sub-model layout and behavior, including checks for multiple sub-models, proper rendering of sub-model headings, and interactions with sub-model parameters and order fields. [[1]](diffhunk://#diff-a4bc7a910dad7ae2e380634afde078af47862cf4b4025ff7a1ef353773965be5L449-R456) [[2]](diffhunk://#diff-a4bc7a910dad7ae2e380634afde078af47862cf4b4025ff7a1ef353773965be5L471-R475) [[3]](diffhunk://#diff-a4bc7a910dad7ae2e380634afde078af47862cf4b4025ff7a1ef353773965be5L1090-R1102) [[4]](diffhunk://#diff-a4bc7a910dad7ae2e380634afde078af47862cf4b4025ff7a1ef353773965be5L1141-R1159) [[5]](diffhunk://#diff-a4bc7a910dad7ae2e380634afde078af47862cf4b4025ff7a1ef353773965be5L1232-R1245)