### PR TITLE
fix: update viewport meta tag for responsive design and adjust layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=768, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>PictRider: Pairwise Testing on the Web</title>
     <meta
       name="description"

--- a/src/sections/ConstraintsSection.tsx
+++ b/src/sections/ConstraintsSection.tsx
@@ -54,7 +54,7 @@ function ConstraintsSection({
   return (
     <Section>
       <div className="mb-5 flex items-center gap-5">
-        <h2 className="text-lg font-bold">Constraints</h2>
+        <h2 className="w-30 text-lg font-bold">Constraints</h2>
         <div>
           <Switch
             label="Enable Constraints"
@@ -69,20 +69,7 @@ function ConstraintsSection({
         <div>
           {!constraintDirectEditMode && (
             <div>
-              <div className="grid grid-cols-2 gap-0 md:grid-cols-3 lg:grid-cols-5 2xl:grid-cols-3">
-                <div>
-                  <div className="h-10 border-collapse border bg-gray-200 px-4 py-2 text-left font-bold">
-                    Parameter
-                  </div>
-                  {parameters.map((p) => (
-                    <div
-                      key={p.id}
-                      className="h-15 border px-4 py-2 text-left align-middle"
-                    >
-                      {p.name}
-                    </div>
-                  ))}
-                </div>
+              <div className="grid grid-cols-1 gap-0 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 2xl:grid-cols-3">
                 {constraints.map((constraint, i) => (
                   <div key={constraint.id}>
                     <div className="flex h-10 border-collapse grid-cols-3 items-center justify-between border bg-gray-200 px-4 py-2 text-left font-bold">
@@ -115,35 +102,43 @@ function ConstraintsSection({
                     {constraint.conditions.map((condition) => (
                       <div
                         key={condition.parameterId}
-                        className="h-15 border-collapse border px-4 py-2 text-left"
+                        className="border-collapse border px-4 py-2 text-left"
                       >
-                        <div className="flex gap-1">
-                          <Button
-                            type="secondary"
-                            size="xs"
-                            fontMono={true}
-                            aria-label={`Constraint ${(i + 1).toString()} ${getParameterName(parameters, condition.parameterId)} ${condition.ifOrThen}`}
-                            onClick={() => {
-                              handleToggleCondition(
-                                constraint.id,
-                                condition.parameterId,
-                              )
-                            }}
-                          >
-                            {condition.ifOrThen}
-                          </Button>
-                          <TextInput
-                            label={`Constraint ${(i + 1).toString()} ${getParameterName(parameters, condition.parameterId)} Predicate`}
-                            value={condition.predicate}
-                            isValid={condition.isValid}
-                            onChange={(e) => {
-                              handleChangeCondition(
-                                constraint.id,
-                                condition.parameterId,
-                                e,
-                              )
-                            }}
-                          />
+                        <div>
+                          <div className="text-sm font-bold">
+                            {getParameterName(
+                              parameters,
+                              condition.parameterId,
+                            )}
+                          </div>
+                          <div className="flex gap-1">
+                            <Button
+                              type="secondary"
+                              size="xs"
+                              fontMono={true}
+                              aria-label={`Constraint ${(i + 1).toString()} ${getParameterName(parameters, condition.parameterId)} ${condition.ifOrThen}`}
+                              onClick={() => {
+                                handleToggleCondition(
+                                  constraint.id,
+                                  condition.parameterId,
+                                )
+                              }}
+                            >
+                              {condition.ifOrThen}
+                            </Button>
+                            <TextInput
+                              label={`Constraint ${(i + 1).toString()} ${getParameterName(parameters, condition.parameterId)} Predicate`}
+                              value={condition.predicate}
+                              isValid={condition.isValid}
+                              onChange={(e) => {
+                                handleChangeCondition(
+                                  constraint.id,
+                                  condition.parameterId,
+                                  e,
+                                )
+                              }}
+                            />
+                          </div>
                         </div>
                       </div>
                     ))}

--- a/src/sections/OptionsSection.tsx
+++ b/src/sections/OptionsSection.tsx
@@ -25,7 +25,7 @@ function OptionsSection({
   return (
     <Section>
       <h2 className="mb-5 text-lg font-bold">Options</h2>
-      <div className="mb-5 grid grid-cols-1 items-center gap-5 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-3">
+      <div className="mb-5 grid grid-cols-1 items-start gap-5 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-3">
         <div>
           <NumberInput
             label="Order of combinations"

--- a/src/sections/ParametersSection.tsx
+++ b/src/sections/ParametersSection.tsx
@@ -23,17 +23,20 @@ function ParametersSection({
 }: ParametersSectionProps) {
   return (
     <Section>
-      <div className="mb-5 grid grid-cols-12 gap-5">
-        <div className="col-span-3">
+      <div className="mb-5 grid grid-cols-12 gap-1 sm:gap-5">
+        <div className="col-span-12 sm:col-span-3">
           <h2 className="text-lg font-bold">Parameters</h2>
         </div>
-        <div className="col-span-2">
+        <div className="sm:col-span-2">
           <h2 className="text-lg font-bold">Values</h2>
         </div>
       </div>
       {parameters.map((p, index) => (
-        <div className="mb-1 grid grid-cols-12 gap-5" key={p.id}>
-          <div className="col-span-3">
+        <div
+          className="mb-3 grid grid-cols-12 gap-0 sm:mb-1 sm:gap-5"
+          key={p.id}
+        >
+          <div className="col-span-11 sm:col-span-3">
             <TextInput
               label={`Parameter ${(index + 1).toString()} Name`}
               value={p.name}
@@ -43,7 +46,7 @@ function ParametersSection({
               }}
             />
           </div>
-          <div className="col-span-8">
+          <div className="col-span-11 sm:col-span-8">
             <TextInput
               label={`Parameter ${(index + 1).toString()} Values`}
               value={p.values}

--- a/src/sections/SubModelsSection.tsx
+++ b/src/sections/SubModelsSection.tsx
@@ -31,7 +31,7 @@ function SubModelsSection({
   return (
     <Section>
       <div className="mb-5 flex items-center gap-5">
-        <h2 className="text-lg font-bold">Sub-Models</h2>
+        <h2 className="w-30 text-lg font-bold">Sub-Models</h2>
         <div>
           <Switch
             label="Enable Sub-Models"

--- a/tests/App.spec.tsx
+++ b/tests/App.spec.tsx
@@ -522,7 +522,6 @@ describe('App', () => {
       expect(
         screen.getByRole('button', { name: 'Remove Constraint' }),
       ).toBeInTheDocument()
-      expect(screen.getByText('Parameter')).toBeInTheDocument() // One in parameters area, one in constraints area
       expect(screen.getByText('Constraint 1')).toBeInTheDocument()
       expect(
         screen.getAllByRole('button', { name: /Constraint [0-9]+ .+ if/ }),


### PR DESCRIPTION
This pull request focuses on improving the responsiveness and accessibility of the UI components across multiple sections, along with minor fixes to layout and test coverage. The most important changes include updates to grid layouts for better responsiveness, adjustments to headings for consistent alignment, and enhancements to the display of constraints and parameters.

### UI Responsiveness and Layout Improvements:

* [`src/sections/ConstraintsSection.tsx`](diffhunk://#diff-76dc4fa03b2ccbf6f88eab7c9061e4a8cce9f75c2460de6cfe49ce426f7724d9L72-R72): Updated grid layouts in the constraints section to improve responsiveness, including changing the number of columns and adjusting the structure of the constraints display. [[1]](diffhunk://#diff-76dc4fa03b2ccbf6f88eab7c9061e4a8cce9f75c2460de6cfe49ce426f7724d9L72-R72) [[2]](diffhunk://#diff-76dc4fa03b2ccbf6f88eab7c9061e4a8cce9f75c2460de6cfe49ce426f7724d9L118-R113) [[3]](diffhunk://#diff-76dc4fa03b2ccbf6f88eab7c9061e4a8cce9f75c2460de6cfe49ce426f7724d9R143)
* [`src/sections/ParametersSection.tsx`](diffhunk://#diff-2a57ba80a6c50cf28714f4086d970087c6fa136cf1d5ccd4150c776df3784303L26-R39): Modified grid gaps and column spans to ensure better alignment and responsiveness, particularly for smaller screen sizes. [[1]](diffhunk://#diff-2a57ba80a6c50cf28714f4086d970087c6fa136cf1d5ccd4150c776df3784303L26-R39) [[2]](diffhunk://#diff-2a57ba80a6c50cf28714f4086d970087c6fa136cf1d5ccd4150c776df3784303L46-R49)
* [`src/sections/OptionsSection.tsx`](diffhunk://#diff-c55eab12ccac7ffaa0aabc902b00a691807652681133866d958a586ed153d560L28-R28): Adjusted grid alignment for options to improve layout consistency.

### Heading Alignment:

* `src/sections/ConstraintsSection.tsx` and `src/sections/SubModelsSection.tsx`: Added a fixed width (`w-30`) to headings in the constraints and sub-models sections for consistent alignment with other elements. [[1]](diffhunk://#diff-76dc4fa03b2ccbf6f88eab7c9061e4a8cce9f75c2460de6cfe49ce426f7724d9L57-R57) [[2]](diffhunk://#diff-e17aeaba3aa0e5624bdc5627f6730c1725828a2522979a53e502b61cd2073e93L34-R34)

### Minor Fixes:

* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L5-R5): Corrected the `viewport` meta tag to use `width=device-width` for proper scaling on different devices.
* [`tests/App.spec.tsx`](diffhunk://#diff-a4bc7a910dad7ae2e380634afde078af47862cf4b4025ff7a1ef353773965be5L525): Removed a redundant test assertion for the "Parameter" text in the constraints area.