### PR TITLE
feat: add reset constraints functionality and corresponding tests

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -157,6 +157,12 @@ function App({ pictRunnerInjection }: AppProps) {
     })
   }
 
+  function handleClickResetConstraints() {
+    dispatchModel({
+      type: 'clickResetConstraints',
+    })
+  }
+
   function handleClickAddSubModel() {
     dispatchModel({
       type: 'clickAddSubModel',
@@ -308,6 +314,7 @@ function App({ pictRunnerInjection }: AppProps) {
             toggleConstraintDirectEditMode={
               handleToggleConstraintDirectEditMode
             }
+            handleClickResetConstraints={handleClickResetConstraints}
           />
           <SubModelsSection
             config={config}

--- a/src/reducers/model-reducer.ts
+++ b/src/reducers/model-reducer.ts
@@ -120,6 +120,7 @@ type ModelAction =
         | 'clickAddConstraint'
         | 'clickRemoveConstraint'
         | 'toggleConstraintDirectEditMode'
+        | 'clickResetConstraints'
         | 'clickAddSubModel'
         | 'clickRemoveSubModel'
     }
@@ -501,6 +502,16 @@ export function modelReducer(state: Model, action: ModelAction): Model {
       return {
         ...structuredClone(state),
         constraintDirectEditMode: !state.constraintDirectEditMode,
+      }
+    }
+
+    case 'clickResetConstraints': {
+      return {
+        ...structuredClone(state),
+        constraints: [createConstraintFromParameters(state.parameters)],
+        constraintTexts: [],
+        constraintDirectEditMode: false,
+        constraintErrors: [],
       }
     }
 

--- a/src/sections/ConstraintsSection.tsx
+++ b/src/sections/ConstraintsSection.tsx
@@ -32,6 +32,7 @@ interface ConstraintsSectionProps {
   handleClickAddConstraint: () => void
   handleClickRemoveConstraint: () => void
   toggleConstraintDirectEditMode: () => void
+  handleClickResetConstraints: () => void
 }
 
 function ConstraintsSection({
@@ -48,6 +49,7 @@ function ConstraintsSection({
   handleClickAddConstraint,
   handleClickRemoveConstraint,
   toggleConstraintDirectEditMode,
+  handleClickResetConstraints,
 }: ConstraintsSectionProps) {
   const [isEditing, setIsEditing] = useState(false)
 
@@ -203,6 +205,15 @@ function ConstraintsSection({
                   ))}
                 </pre>
               </>
+            )}
+            {constraintDirectEditMode && (
+              <Button
+                type="warning"
+                size="md"
+                onClick={handleClickResetConstraints}
+              >
+                Reset Constraints
+              </Button>
             )}
           </div>
           <AlertMessage messages={messages} />

--- a/tests/App.spec.tsx
+++ b/tests/App.spec.tsx
@@ -808,6 +808,26 @@ describe('App', () => {
         screen.queryByRole('button', { name: 'Remove Constraint' }),
       ).not.toBeInTheDocument()
     })
+
+    it('Should reset constraints when click reset button', async () => {
+      // arrange
+      await user.click(
+        screen.getByRole('switch', { name: 'Enable Constraints' }),
+      )
+      await user.click(screen.getByRole('button', { name: 'Edit Directly' }))
+      expect(
+        screen.getByRole('textbox', { name: 'Constraint Formula' }),
+      ).toBeInTheDocument()
+
+      // act
+      await user.click(
+        screen.getByRole('button', { name: 'Reset Constraints' }),
+      )
+
+      // assert
+      expect(screen.queryByText('Constraint 1')).toBeInTheDocument()
+      expect(screen.queryByText('Constraint 2')).not.toBeInTheDocument()
+    })
   })
 
   describe('Run Pict', () => {


### PR DESCRIPTION
This pull request introduces a new feature to reset constraints in the application. It includes updates to the state management, UI components, and tests to support this functionality.

### New Feature: Reset Constraints

#### State Management Updates:
* Added a new action type `'clickResetConstraints'` to the `ModelAction` union type in `src/reducers/model-reducer.ts`.
* Implemented the `'clickResetConstraints'` case in the `modelReducer` function to reset constraints, constraint texts, direct edit mode, and errors to their initial states.

#### UI Component Updates:
* Added a `handleClickResetConstraints` prop to the `ConstraintsSection` component in `src/sections/ConstraintsSection.tsx`. [[1]](diffhunk://#diff-76dc4fa03b2ccbf6f88eab7c9061e4a8cce9f75c2460de6cfe49ce426f7724d9R35) [[2]](diffhunk://#diff-76dc4fa03b2ccbf6f88eab7c9061e4a8cce9f75c2460de6cfe49ce426f7724d9R52)
* Introduced a "Reset Constraints" button in the `ConstraintsSection` component, displayed only in direct edit mode. The button triggers the `handleClickResetConstraints` function.
* Passed the `handleClickResetConstraints` function from `App` to `ConstraintsSection` in `src/App.tsx`. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R160-R165) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R317)

#### Tests:
* Added a new test case in `tests/App.spec.tsx` to verify that clicking the "Reset Constraints" button correctly resets the constraints to their initial state.