### PR TITLE
fix: refine editing condition in ConstraintsSection

### DIFF
--- a/src/sections/ConstraintsSection.tsx
+++ b/src/sections/ConstraintsSection.tsx
@@ -150,7 +150,7 @@ function ConstraintsSection({
             </div>
           )}
           <div className="mt-3">
-            {isEditing ? (
+            {constraintDirectEditMode && isEditing ? (
               <>
                 <label
                   className="mb-2 block text-base font-bold text-gray-900 dark:text-white"


### PR DESCRIPTION
This pull request updates the `ConstraintsSection` component to refine the behavior of its editing mode. The most important change introduces a new condition, `constraintDirectEditMode`, to ensure that direct editing is only enabled when both `constraintDirectEditMode` and `isEditing` are true.

Behavior refinement:

* [`src/sections/ConstraintsSection.tsx`](diffhunk://#diff-76dc4fa03b2ccbf6f88eab7c9061e4a8cce9f75c2460de6cfe49ce426f7724d9L153-R153): Updated the conditional rendering logic to include `constraintDirectEditMode` alongside `isEditing` for determining when the direct editing mode should be displayed.