### PR TITLE
refactor: simplify App, MainArea, TopPanel, and MenuSection components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect, useRef } from 'react'
 import { PictRunner } from '@takeyaqa/pict-browser'
 import { Analytics } from './components'
 import {
@@ -6,7 +5,6 @@ import {
   NotificationMessageSection,
   FooterSection,
 } from './sections'
-import { Result } from './types'
 import { ConfigProvider } from './features/config'
 import { ModelProvider } from './features/model'
 import { MainArea } from './layouts'
@@ -16,27 +14,6 @@ interface AppProps {
 }
 
 function App({ pictRunnerInjection }: AppProps) {
-  const [result, setResult] = useState<Result | null>(null)
-  const [pictRunnerLoaded, setPictRunnerLoaded] = useState(false)
-  const pictRunner = useRef<PictRunner>(null)
-
-  useEffect(() => {
-    // Use the injected PictRunner for testing
-    if (pictRunnerInjection) {
-      pictRunner.current = pictRunnerInjection
-      setPictRunnerLoaded(true)
-      return
-    }
-    const loadPictRunner = async () => {
-      pictRunner.current = new PictRunner()
-      await pictRunner.current.init()
-      setPictRunnerLoaded(true)
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    loadPictRunner()
-  }, [pictRunnerInjection])
-
   return (
     <>
       <HeaderSection />
@@ -45,12 +22,7 @@ function App({ pictRunnerInjection }: AppProps) {
       />
       <ConfigProvider>
         <ModelProvider>
-          <MainArea
-            pictRunnerLoaded={pictRunnerLoaded}
-            pictRunner={pictRunner}
-            result={result}
-            setResult={setResult}
-          />
+          <MainArea pictRunnerInjection={pictRunnerInjection} />
         </ModelProvider>
       </ConfigProvider>
       <FooterSection />

--- a/src/layouts/MainArea.tsx
+++ b/src/layouts/MainArea.tsx
@@ -1,22 +1,15 @@
 import { PictRunner } from '@takeyaqa/pict-browser'
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Result } from '../types'
 import TopPanel from './TopPanel'
 import BottomPanel from './BottomPanel'
 
 interface MainAreaProps {
-  pictRunnerLoaded: boolean
-  pictRunner: React.RefObject<PictRunner | null>
-  result: Result | null
-  setResult: (result: Result | null) => void
+  pictRunnerInjection?: PictRunner // use for testing
 }
 
-function MainArea({
-  pictRunnerLoaded,
-  pictRunner,
-  result,
-  setResult,
-}: MainAreaProps) {
+function MainArea({ pictRunnerInjection }: MainAreaProps) {
+  const [result, setResult] = useState<Result | null>(null)
   const resultSection = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -36,8 +29,7 @@ function MainArea({
   return (
     <main className="grid grid-cols-1 2xl:grid-cols-2">
       <TopPanel
-        pictRunnerLoaded={pictRunnerLoaded}
-        pictRunner={pictRunner}
+        pictRunnerInjection={pictRunnerInjection}
         result={result}
         setResult={setResult}
       />

--- a/src/layouts/TopPanel.tsx
+++ b/src/layouts/TopPanel.tsx
@@ -1,4 +1,3 @@
-import { PictRunner } from '@takeyaqa/pict-browser'
 import { Result } from '../types'
 import {
   MenuSection,
@@ -7,26 +6,20 @@ import {
   SubModelsSection,
   OptionsSection,
 } from '../sections'
+import { PictRunner } from '@takeyaqa/pict-browser'
 
 interface TopPanelProps {
-  pictRunnerLoaded: boolean
-  pictRunner: React.RefObject<PictRunner | null>
+  pictRunnerInjection?: PictRunner // use for testing
   result: Result | null
   setResult: (result: Result | null) => void
 }
 
-function TopPanel({
-  pictRunnerLoaded,
-  pictRunner,
-  result,
-  setResult,
-}: TopPanelProps) {
+function TopPanel({ pictRunnerInjection, result, setResult }: TopPanelProps) {
   return (
     <div>
       <MenuSection
-        pictRunnerLoaded={pictRunnerLoaded}
+        pictRunnerInjection={pictRunnerInjection} // use for testing
         canClearResult={result !== null}
-        pictRunner={pictRunner}
         handleClearResult={() => {
           setResult(null)
         }}

--- a/src/sections/MenuSection.tsx
+++ b/src/sections/MenuSection.tsx
@@ -4,24 +4,43 @@ import { useConfig } from '../features/config'
 import { Result } from '../types'
 import { uuidv4 } from '../helpers'
 import { useModel } from '../features/model'
+import { useEffect, useRef, useState } from 'react'
 
 interface MenuSectionProps {
-  pictRunnerLoaded: boolean
-  pictRunner: React.RefObject<PictRunner | null>
+  pictRunnerInjection?: PictRunner // use for testing
   canClearResult: boolean
   handleClearResult: () => void
   setResult: (result: Result) => void
 }
 
 function MenuSection({
-  pictRunnerLoaded,
-  pictRunner,
+  pictRunnerInjection,
   canClearResult,
   handleClearResult,
   setResult,
 }: MenuSectionProps) {
+  const [pictRunnerLoaded, setPictRunnerLoaded] = useState(false)
+  const pictRunner = useRef<PictRunner>(null)
+
   const { config } = useConfig()
   const { model, handlers } = useModel()
+
+  useEffect(() => {
+    // Use the injected PictRunner for testing
+    if (pictRunnerInjection) {
+      pictRunner.current = pictRunnerInjection
+      setPictRunnerLoaded(true)
+      return
+    }
+    const loadPictRunner = async () => {
+      pictRunner.current = new PictRunner()
+      await pictRunner.current.init()
+      setPictRunnerLoaded(true)
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    loadPictRunner()
+  }, [pictRunnerInjection])
 
   function runPict() {
     if (!pictRunnerLoaded || !pictRunner.current) {


### PR DESCRIPTION
This pull request refactors the handling of the `PictRunner` instance to improve testability and simplify the component structure. The most important changes include moving the initialization logic for `PictRunner` from `App` to `MenuSection`, updating the props structure for `MainArea` and its child components, and ensuring that `PictRunner` can be injected for testing purposes.

### Refactoring for `PictRunner` Initialization:
* Removed `PictRunner` initialization logic from `App` and moved it to `MenuSection`, making it the sole component responsible for managing `PictRunner` state and lifecycle. (`src/App.tsx` [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L19-L39) `src/sections/MenuSection.tsx` [[2]](diffhunk://#diff-b70709b9d244eb3ed86c4f7197cc9c59dbd4f92d7a74c6e56616e1d10c148254R7-R44)

### Component Prop Updates:
* Updated `MainArea` and its child components (`TopPanel` and `MenuSection`) to accept a `pictRunnerInjection` prop instead of separate `pictRunner` and `pictRunnerLoaded` props. This simplifies the prop structure and improves clarity. (`src/layouts/MainArea.tsx` [[1]](diffhunk://#diff-d0f36af180681a0b275cbc87dbbaeda10c4a6a6d1d4f7804293cda3beb222fdfL2-R12) [[2]](diffhunk://#diff-d0f36af180681a0b275cbc87dbbaeda10c4a6a6d1d4f7804293cda3beb222fdfL39-R32); `src/layouts/TopPanel.tsx` [[3]](diffhunk://#diff-8cfb576e6033582cbb160856ea27453878f1bb3b6357abe89a33c48c4f9dd3a6R9-L29)

### Testability Improvements:
* Added support for injecting a `PictRunner` instance into `MenuSection` and its parent components, enabling easier testing by bypassing the default `PictRunner` initialization logic. (`src/sections/MenuSection.tsx` [src/sections/MenuSection.tsxR7-R44](diffhunk://#diff-b70709b9d244eb3ed86c4f7197cc9c59dbd4f92d7a74c6e56616e1d10c148254R7-R44))

These changes streamline the codebase by centralizing `PictRunner` management and making the components more modular and testable.