### PR TITLE
chore: bump version to 0.13.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pictrider",
   "private": true,
-  "version": "0.13.1",
+  "version": "0.13.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This pull request includes a version bump in the `package.json` file to reflect a new release.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the `version` field from `0.13.1` to `0.13.2` to indicate a new release.