### PR TITLE
build: update deployment workflow to use GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,13 +6,25 @@ on:
 env:
   PNPM_VERSION: 10
   NODE_VERSION: 22
-    
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      deployments: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -28,10 +40,12 @@ jobs:
           VITE_APP_VERSION: ${{ github.event.release.tag_name }}
           VITE_BASE_DOMAIN: ${{ vars.BASE_DOMAIN }}
           VITE_NOTIFICATION_MESSAGE: ${{ vars.NOTIFICATION_MESSAGE }}
-      - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          command: pages deploy dist --project-name=pictrider --branch=main
+          path: 'dist'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deployment, transitioning from Cloudflare Pages to GitHub Pages. The changes include adjustments to permissions, concurrency settings, environment variables, and steps for deployment.

### Transition to GitHub Pages:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R10-R27): Updated permissions to allow deployment to GitHub Pages by setting `contents: read`, `pages: write`, and `id-token: write`.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L31-R51): Replaced the deployment steps for Cloudflare Pages with GitHub Pages actions (`actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages`).

### Workflow Enhancements:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R10-R27): Added `concurrency` settings to ensure only one deployment runs at a time, without canceling in-progress runs.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R10-R27): Defined a new environment for GitHub Pages with `name: github-pages` and `url` dynamically set from deployment outputs.