### PR TITLE
chore: change update schedule from daily to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,21 +3,24 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    open-pull-requests-limit: 10
     commit-message:
       prefix: "build"
       include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    open-pull-requests-limit: 10
     commit-message:
       prefix: "ci"
       include: "scope"
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    open-pull-requests-limit: 10
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
This pull request updates the Dependabot configuration file `.github/dependabot.yml` to reduce the frequency of updates and limit the number of open pull requests.

Dependabot configuration updates:

* Changed the update schedule for `npm`, `github-actions`, and `devcontainers` ecosystems from "daily" to "weekly" to reduce update frequency.
* Added a limit of 10 open pull requests for each ecosystem to prevent an excessive number of updates from being active simultaneously.