### PR TITLE
chore: update version to 0.15.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pictrider",
   "private": true,
-  "version": "0.13.2",
+  "version": "0.15.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This pull request makes a version update to the `package.json` file for the `pictrider` project.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the project version from `0.13.2` to `0.15.0`.