### PR TITLE
build(deps): update @takeyaqa/pict-wasm to version 3.7.4-wasm.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@plausible-analytics/tracker": "^0.4.4",
-    "@takeyaqa/pict-wasm": "3.7.4-wasm.18",
+    "@takeyaqa/pict-wasm": "3.7.4-wasm.21",
     "immer": "^11.1.4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^0.4.4
         version: 0.4.4
       '@takeyaqa/pict-wasm':
-        specifier: 3.7.4-wasm.18
-        version: 3.7.4-wasm.18
+        specifier: 3.7.4-wasm.21
+        version: 3.7.4-wasm.21
       immer:
         specifier: ^11.1.4
         version: 11.1.4
@@ -1230,8 +1230,8 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@takeyaqa/pict-wasm@3.7.4-wasm.18':
-    resolution: {integrity: sha512-NcRJ377cACFtm8S/2wkKMiRvYNS2TfrDAvnTORNaiCdqQuthXtUHJB1UNAuYr2m1yBT7f2hpEqoKt4+0V7tHSg==}
+  '@takeyaqa/pict-wasm@3.7.4-wasm.21':
+    resolution: {integrity: sha512-z2Sl6RsXerpLlMsl4wOkhXV4YWdLkVdy1Pt+G22MCzbJbsR6PYenNi1RCArT0v6cGp7KU3nxVBWWKCtPnzZ4Kg==}
     engines: {node: ^22 || ^24}
 
   '@tanstack/react-virtual@3.13.24':
@@ -4257,7 +4257,7 @@ snapshots:
       tailwindcss: 4.2.4
       vite: 8.0.10(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.2)
 
-  '@takeyaqa/pict-wasm@3.7.4-wasm.18': {}
+  '@takeyaqa/pict-wasm@3.7.4-wasm.21': {}
 
   '@tanstack/react-virtual@3.13.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:


### PR DESCRIPTION
This pull request updates the `@takeyaqa/pict-wasm` dependency to version `3.7.4-wasm.21` throughout the project. This ensures the project is using the latest compatible version of this package.

Dependency updates:

* Updated `@takeyaqa/pict-wasm` from version `3.7.4-wasm.18` to `3.7.4-wasm.21` in `package.json`, `pnpm-lock.yaml` (`importers`, `packages`, and `snapshots` sections) to keep dependencies up-to-date and potentially include bug fixes or improvements. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L24-R24) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL21-R22) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1233-R1234) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4260-R4260)