### PR TITLE
chore: increase open-pull-requests-limit to 20

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: "monthly"
     cooldown:
       default-days: 1
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
     commit-message:
       prefix: "build"
       include: "scope"


### PR DESCRIPTION
This pull request makes a small configuration change to the Dependabot settings. The maximum number of open pull requests allowed by Dependabot has been increased from 10 to 20.