### PR TITLE
chore: Increase dependency release and Dependabot cooldown windows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: "monthly"
     versioning-strategy: increase
     cooldown:
-      default-days: 1
+      default-days: 3
     open-pull-requests-limit: 20
     commit-message:
       prefix: "build"
@@ -54,7 +54,7 @@ updates:
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 1
+      default-days: 3
     commit-message:
       prefix: "ci"
       include: "scope"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
-minimumReleaseAge: 1440
+minimumReleaseAge: 4320
 minimumReleaseAgeExclude:
   - "@takeyaqa/pict-wasm"
 trustPolicy: no-downgrade


### PR DESCRIPTION
## Summary
- Increase Dependabot cooldowns from 1 day to 3 days for the affected update groups
- Raise `pnpm` minimum release age from 1440 to 4320 minutes to allow a longer stabilization period before adoption

## Testing
- Not run (not requested)